### PR TITLE
Refactor, date_commit is now used to commit budget

### DIFF
--- a/budget_control/models/analytic_account.py
+++ b/budget_control/models/analytic_account.py
@@ -1,7 +1,7 @@
 # Copyright 2021 Ecosoft Co., Ltd. (http://ecosoft.co.th)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import _, fields, models
+from odoo import _, api, fields, models
 from odoo.exceptions import UserError
 
 
@@ -13,6 +13,20 @@ class AccountAnalyticAccount(models.Model):
         comodel_name="budget.control",
         readonly=True,
     )
+    bm_date_from = fields.Date(
+        string="Date From",
+        compute="_compute_bm_date",
+        store=True,
+        readonly=False,
+        help="Budget commit date must conform with this date",
+    )
+    bm_date_to = fields.Date(
+        string="Date To",
+        compute="_compute_bm_date",
+        store=True,
+        readonly=False,
+        help="Budget commit date must conform with this date",
+    )
 
     def _check_budget_control_status(self):
         """ Throw error when has budget_control, but not in controlled """
@@ -22,3 +36,10 @@ class AccountAnalyticAccount(models.Model):
         if budget_controls:
             names = budget_controls.mapped("analytic_account_id.display_name")
             raise UserError(_("Budget not controlled: %s") % ", ".join(names))
+
+    @api.depends("budget_period_id")
+    def _compute_bm_date(self):
+        """Default effective date, but changable"""
+        for rec in self:
+            rec.bm_date_from = rec.budget_period_id.bm_date_from
+            rec.bm_date_to = rec.budget_period_id.bm_date_to

--- a/budget_control/report/budget_monitor_report.py
+++ b/budget_control/report/budget_monitor_report.py
@@ -34,10 +34,25 @@ class BudgetMonitorReport(models.Model):
     account_id = fields.Many2one(
         comodel_name="account.account",
     )
+    date_range_id = fields.Many2one(
+        comodel_name="date.range",
+    )
+    budget_period_id = fields.Many2one(
+        comodel_name="budget.period",
+    )
 
     @property
     def _table_query(self):
-        return "%s" % (self._get_sql())
+        return """
+            select a.*, d.id as date_range_id, p.id as budget_period_id
+            from (%s) a
+            left outer join date_range d
+                on a.date between d.date_start and d.date_end
+            left outer join budget_period p
+                on a.date between p.bm_date_from and p.bm_date_to
+        """ % (
+            self._get_sql()
+        )
 
     def _select_budget(self):
         return [

--- a/budget_control_advance_clearing/models/hr_expense.py
+++ b/budget_control_advance_clearing/models/hr_expense.py
@@ -14,7 +14,7 @@ class HRExpense(models.Model):
     @api.depends(
         "budget_move_ids", "budget_move_ids.date", "advance_budget_move_ids"
     )
-    def _compute_commit(self):
+    def _compute_amount_commit(self):
         for rec in self:
             if rec.advance_budget_move_ids:
                 advance_id = rec.sheet_id.advance_sheet_id
@@ -23,9 +23,6 @@ class HRExpense(models.Model):
                     debit = sum(rec.advance_budget_move_ids.mapped("debit"))
                     credit = sum(rec.advance_budget_move_ids.mapped("credit"))
                     rec.amount_commit = debit - credit
-                    rec.date_commit = min(
-                        rec.advance_budget_move_ids.mapped("date")
-                    )
                     continue
                 # commit advance previous
                 debit = sum(advance_id.advance_budget_move_ids.mapped("debit"))
@@ -38,11 +35,8 @@ class HRExpense(models.Model):
                 debit = sum(rec.budget_move_ids.mapped("debit"))
                 credit = sum(rec.budget_move_ids.mapped("credit"))
                 rec.amount_commit = debit - credit
-                rec.date_commit = min(
-                    rec.advance_budget_move_ids.mapped("date")
-                )
             else:
-                super()._compute_commit()
+                super()._compute_amount_commit()
 
     def _budget_move_create(self, vals):
         """

--- a/budget_control_expense/models/hr_expense.py
+++ b/budget_control_expense/models/hr_expense.py
@@ -6,6 +6,7 @@ from odoo import fields, models
 class HRExpense(models.Model):
     _name = "hr.expense"
     _inherit = ["hr.expense", "budget.docline.mixin"]
+    _doc_date_fields = ["sheet_id.write_date"]
 
     budget_move_ids = fields.One2many(
         comodel_name="expense.budget.move",
@@ -41,20 +42,17 @@ class HRExpense(models.Model):
     def commit_budget(self, reverse=False):
         """Create budget commit for each expense."""
         for expense in self:
-            if expense.state in ("approved", "done"):
-                if not self.filtered_domain(
-                    self._budget_domain
-                ):  # With correct dom
-                    return
+            if expense.can_commit() and expense.state in ("approved", "done"):
                 account = expense.account_id
                 analytic_account = expense.analytic_account_id
-                doc_date = expense.date
-                amount_currency = expense._check_amount_currency_tax(doc_date)
+                amount_currency = expense._check_amount_currency_tax(
+                    self.date_commit
+                )
                 currency = expense.currency_id
                 vals = expense._prepare_budget_commitment(
                     account,
                     analytic_account,
-                    doc_date,
+                    self.date_commit,
                     amount_currency,
                     currency,
                     reverse=reverse,


### PR DESCRIPTION
* Doc Line's `date_commit` will be computed from Doc Date and will be used as date in budget move. 
* `date_commit` must be within Analytic's Data From and Date To
* Analytic should be used > 1 years
* Budget Monitor Report's new column Budget Period and Date Range