### PR TITLE
Fix compute_budget_info

### DIFF
--- a/budget_control/models/analytic_account.py
+++ b/budget_control/models/analytic_account.py
@@ -49,9 +49,9 @@ class AccountAnalyticAccount(models.Model):
         help="Consumed = Total Commitments + Actual",
     )
     amount_balance = fields.Monetary(
-        string="Balance",
+        string="Available",
         compute="_compute_amount_budget_info",
-        help="Balance = Total Budget - Consumed",
+        help="Available = Total Budget - Consumed",
     )
 
     def _compute_amount_budget_info(self):

--- a/budget_control/models/budget_control.py
+++ b/budget_control/models/budget_control.py
@@ -137,9 +137,9 @@ class BudgetControl(models.Model):
         help="Consumed = Total Commitments + Actual",
     )
     amount_balance = fields.Monetary(
-        string="Balance",
+        string="Available",
         compute="_compute_budget_info",
-        help="Balance = Total Budget - Consumed",
+        help="Available = Total Budget - Consumed",
     )
     state = fields.Selection(
         [

--- a/budget_control_advance_clearing/models/budget_period.py
+++ b/budget_control_advance_clearing/models/budget_period.py
@@ -34,15 +34,6 @@ class BudgetPeriod(models.Model):
             periods.update({advance: "-"})
         return periods
 
-    def _set_budget_info_amount(self, source, domain, kwargs):
-        budget_info = super()._set_budget_info_amount(source, domain, kwargs)
-        if budget_info.get("amount_advance"):
-            budget_info["amount_commit"] += budget_info["amount_advance"]
-            budget_info["amount_consumed"] = (
-                budget_info["amount_commit"] + budget_info["amount_actual"]
-            )
-        return budget_info
-
     def _compute_budget_info(self, **kwargs):
         """ Add more data info budget_info, based on installed modules """
         super()._compute_budget_info(**kwargs)
@@ -50,6 +41,7 @@ class BudgetPeriod(models.Model):
             "amount_advance",
             [("source_aml_model_id.model", "=", "advance.budget.move")],
             kwargs,
+            is_commit=True,
         )
 
     @api.model

--- a/budget_control_expense/models/budget_period.py
+++ b/budget_control_expense/models/budget_period.py
@@ -34,15 +34,6 @@ class BudgetPeriod(models.Model):
             periods.update({expense: "-"})
         return periods
 
-    def _set_budget_info_amount(self, source, domain, kwargs):
-        budget_info = super()._set_budget_info_amount(source, domain, kwargs)
-        if budget_info.get("amount_expense"):
-            budget_info["amount_commit"] += budget_info["amount_expense"]
-            budget_info["amount_consumed"] = (
-                budget_info["amount_commit"] + budget_info["amount_actual"]
-            )
-        return budget_info
-
     def _compute_budget_info(self, **kwargs):
         """ Add more data info budget_info, based on installed modules """
         super()._compute_budget_info(**kwargs)
@@ -50,4 +41,5 @@ class BudgetPeriod(models.Model):
             "amount_expense",
             [("source_aml_model_id.model", "=", "expense.budget.move")],
             kwargs,
+            is_commit=True,
         )

--- a/budget_control_purchase/models/budget_period.py
+++ b/budget_control_purchase/models/budget_period.py
@@ -34,15 +34,6 @@ class BudgetPeriod(models.Model):
             periods.update({purchase: "-"})
         return periods
 
-    def _set_budget_info_amount(self, source, domain, kwargs):
-        budget_info = super()._set_budget_info_amount(source, domain, kwargs)
-        if budget_info.get("amount_purchase"):
-            budget_info["amount_commit"] += budget_info["amount_purchase"]
-            budget_info["amount_consumed"] = (
-                budget_info["amount_commit"] + budget_info["amount_actual"]
-            )
-        return budget_info
-
     def _compute_budget_info(self, **kwargs):
         """ Add more data info budget_info, based on installed modules """
         super()._compute_budget_info(**kwargs)
@@ -50,4 +41,5 @@ class BudgetPeriod(models.Model):
             "amount_purchase",
             [("source_aml_model_id.model", "=", "purchase.budget.move")],
             kwargs,
+            is_commit=True,
         )

--- a/budget_control_purchase_request/models/budget_period.py
+++ b/budget_control_purchase_request/models/budget_period.py
@@ -34,17 +34,6 @@ class BudgetPeriod(models.Model):
             periods.update({purchase_request: "-"})
         return periods
 
-    def _set_budget_info_amount(self, source, domain, kwargs):
-        budget_info = super()._set_budget_info_amount(source, domain, kwargs)
-        if budget_info.get("amount_purchase_request"):
-            budget_info["amount_commit"] += budget_info[
-                "amount_purchase_request"
-            ]
-            budget_info["amount_consumed"] = (
-                budget_info["amount_commit"] + budget_info["amount_actual"]
-            )
-        return budget_info
-
     def _compute_budget_info(self, **kwargs):
         """ Add more data info budget_info, based on installed modules """
         super()._compute_budget_info(**kwargs)
@@ -58,4 +47,5 @@ class BudgetPeriod(models.Model):
                 )
             ],
             kwargs,
+            is_commit=True,
         )


### PR DESCRIPTION
The recent change in _compute_budget_info can't pass budget_control's test.

```
  File "/opt/odoo/auto/addons/budget_control_purchase/models/budget_period.py", line 38, in _set_budget_info_amount
    budget_info = super()._set_budget_info_amount(source, domain, kwargs)
  File "/opt/odoo/auto/addons/budget_control_expense/models/budget_period.py", line 39, in _set_budget_info_amount
    if budget_info.get("amount_expense"):
AttributeError: 'NoneType' object has no attribute 'get'
```