### PR TITLE
[14.0][FIX] budget_control_operating_unit, error if the model has no OU

### DIFF
--- a/budget_control_operating_unit/models/base_budget_move.py
+++ b/budget_control_operating_unit/models/base_budget_move.py
@@ -15,19 +15,15 @@ class BaseBudgetMove(models.AbstractModel):
 class BudgetDoclineMixin(models.AbstractModel):
     _inherit = "budget.docline.mixin"
 
-    operating_unit_id = fields.Many2one(
-        comodel_name="operating.unit",
-        index=True,
-    )
-
     def _update_budget_commitment(self, budget_vals, reverse=False):
         budget_vals = super()._update_budget_commitment(
             budget_vals, reverse=reverse
         )
-        if self.operating_unit_id:
-            ou_line = self.operating_unit_id.id
-        else:
-            # get ou from header if line not selected ou.
-            ou_line = self[self._doc_rel].operating_unit_id.id
-        budget_vals["operating_unit_id"] = ou_line
+        # docline's OU has priority over docline's header OU.
+        if hasattr(self, "operating_unit_id"):
+            budget_vals["operating_unit_id"] = self.operating_unit_id.id
+        elif hasattr(self[self._doc_rel], "operating_unit_id"):
+            budget_vals["operating_unit_id"] = self[
+                self._doc_rel
+            ].operating_unit_id.id
         return budget_vals


### PR DESCRIPTION
Now, we have error when working with some object without OU (yet), i.e., contract.

cc @Saran440 please review and merge this if you agree.