### PR TITLE
[14.0][IMP] budget_control, allow commit note

### DIFF
--- a/budget_control/models/base_budget_move.py
+++ b/budget_control/models/base_budget_move.py
@@ -59,6 +59,9 @@ class BaseBudgetMove(models.AbstractModel):
         default=lambda self: self.env.user.company_id.id,
         index=True,
     )
+    note = fields.Char(
+        readonly=True,
+    )
 
 
 class BudgetDoclineMixin(models.AbstractModel):
@@ -233,6 +236,8 @@ class BudgetDoclineMixin(models.AbstractModel):
             budget_vals = self._update_budget_commitment(
                 budget_vals, reverse=reverse
             )
+            # Final note
+            budget_vals["note"] = self.env.context.get("commit_note")
             # Create budget move
             if not budget_vals["amount_currency"]:
                 return False
@@ -314,6 +319,7 @@ class BudgetDoclineMixin(models.AbstractModel):
     def close_budget_move(self):
         """ Reverse commit with amount_commit/date_commit to zero budget """
         for docline in self:
-            docline.with_context(use_amount_commit=True).commit_budget(
-                reverse=True
-            )
+            docline.with_context(
+                use_amount_commit=True,
+                commit_note=_("Auto adjustment on close budget"),
+            ).commit_budget(reverse=True)

--- a/budget_control/views/account_move_views.xml
+++ b/budget_control/views/account_move_views.xml
@@ -47,6 +47,7 @@
                             />
                             <field name="write_uid" optional="show" />
                             <field name="write_date" optional="show" />
+                            <field name="note" optionl="hide" />
                             <field name="debit" sum="Total Debit" />
                             <field name="credit" sum="Total Credit" />
                         </tree>

--- a/budget_control_advance_clearing/views/hr_expense_view.xml
+++ b/budget_control_advance_clearing/views/hr_expense_view.xml
@@ -62,6 +62,7 @@
                             />
                             <field name="write_uid" optional="show" />
                             <field name="write_date" optional="show" />
+                            <field name="note" optionl="hide" />
                             <field name="debit" sum="Total Debit" />
                             <field name="credit" sum="Total Credit" />
                         </tree>

--- a/budget_control_contract/views/contract_view.xml
+++ b/budget_control_contract/views/contract_view.xml
@@ -47,6 +47,7 @@
                             />
                             <field name="write_uid" optional="show" />
                             <field name="write_date" optional="show" />
+                            <field name="note" optionl="hide" />
                             <field name="debit" sum="Total Debit" />
                             <field name="credit" sum="Total Credit" />
                         </tree>

--- a/budget_control_expense/views/hr_expense_view.xml
+++ b/budget_control_expense/views/hr_expense_view.xml
@@ -50,6 +50,7 @@
                             />
                             <field name="write_uid" optional="show" />
                             <field name="write_date" optional="show" />
+                            <field name="note" optionl="hide" />
                             <field name="debit" sum="Total Debit" />
                             <field name="credit" sum="Total Credit" />
                         </tree>

--- a/budget_control_purchase/views/purchase_view.xml
+++ b/budget_control_purchase/views/purchase_view.xml
@@ -53,6 +53,7 @@
                             />
                             <field name="write_uid" optional="show" />
                             <field name="write_date" optional="show" />
+                            <field name="note" optionl="hide" />
                             <field name="debit" sum="Total Debit" />
                             <field name="credit" sum="Total Credit" />
                         </tree>

--- a/budget_control_purchase_request/views/purchase_request_view.xml
+++ b/budget_control_purchase_request/views/purchase_request_view.xml
@@ -41,6 +41,7 @@
                             />
                             <field name="write_uid" optional="show" />
                             <field name="write_date" optional="show" />
+                            <field name="note" optionl="hide" />
                             <field name="debit" sum="Total Debit" />
                             <field name="credit" sum="Total Credit" />
                         </tree>


### PR DESCRIPTION
Now, we can pass context["commit_note"] when create new budget move

![image](https://user-images.githubusercontent.com/1973598/119962803-9e4f4f80-bfd1-11eb-9be8-6d8487c4bbb5.png)

![image](https://user-images.githubusercontent.com/1973598/119962817-a1e2d680-bfd1-11eb-89c4-5d5a74b34489.png)
