### PR TITLE
[IMP] budget_control with job order and update consumed

### DIFF
--- a/budget_control_consumed_plan/models/budget_control.py
+++ b/budget_control_consumed_plan/models/budget_control.py
@@ -1,7 +1,7 @@
 # Copyright 2021 Ecosoft Co., Ltd. (http://ecosoft.co.th)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import _, fields, models
+from odoo import _, models
 
 
 class BudgetControl(models.Model):
@@ -70,9 +70,13 @@ class BudgetControl(models.Model):
         item_ids = self.item_ids.filtered(lambda l: l.date_from <= date)
         self._update_consumed_value(item_ids, date)
 
+    def _get_last_date_period(self):
+        date_to = max(self.mapped("date_to"))
+        return date_to
+
     def update_consumed_plan(self, date=False):
         if not date:
-            date = fields.Date.context_today(self)
+            date = self._get_last_date_period()
         for rec in self:
             if rec.item_ids:
                 rec._get_consumed_plan(date)

--- a/budget_control_consumed_plan/wizards/update_consumed_plan.py
+++ b/budget_control_consumed_plan/wizards/update_consumed_plan.py
@@ -1,7 +1,7 @@
 # Copyright 2021 Ecosoft Co., Ltd. (http://ecosoft.co.th)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import fields, models
+from odoo import api, fields, models
 
 
 class UpdateConsumedPlan(models.TransientModel):
@@ -10,10 +10,17 @@ class UpdateConsumedPlan(models.TransientModel):
 
     date_to = fields.Date(
         string="End Date",
-        default=fields.Date.context_today,
+        default=lambda self: self._default_last_date_period(),
         required=True,
-        help="End of date",
+        help="This field is maximum of 'date to' from budget control",
     )
+
+    @api.model
+    def _default_last_date_period(self):
+        active_ids = self._context.get("active_ids", False)
+        budget_control_ids = self.env["budget.control"].browse(active_ids)
+        budget_control_ids._get_last_date_period()
+        return budget_control_ids._get_last_date_period()
 
     def confirm(self):
         self.ensure_one()

--- a/budget_job_order/models/mis_budget_item.py
+++ b/budget_job_order/models/mis_budget_item.py
@@ -12,10 +12,19 @@ class MisBudgetItem(models.Model):
         ondelete="cascade",
         index=True,
     )
+    job_sequence = fields.Integer(
+        default=1,
+        help="This field help check same KPIs, diff job order",
+    )
 
     def _prepare_overlap_domain(self):
         domain = super()._prepare_overlap_domain()
-        domain.extend([("job_order_id", "=", self.job_order_id.id)])
+        domain.extend(
+            [
+                ("job_order_id", "=", self.job_order_id.id),
+                ("job_sequence", "=", self.job_sequence),
+            ]
+        )
         return domain
 
     def _compute_name(self):

--- a/budget_job_order/views/budget_control_view.xml
+++ b/budget_job_order/views/budget_control_view.xml
@@ -5,10 +5,10 @@
         <field name="model">budget.control</field>
         <field name="inherit_id" ref="budget_control.budget_control_view_form" />
         <field name="arch" type="xml">
-            <field name="use_all_kpis" position="after">
+            <field name="use_all_kpis" position="before">
                 <field name="use_all_job_order" widget="boolean_toggle" />
             </field>
-            <field name="kpi_ids" position="after">
+            <field name="kpi_ids" position="before">
                 <field
                     name="job_order_ids"
                     widget="many2many_tags"
@@ -18,16 +18,17 @@
             <xpath expr="//page[@name='options']" position="inside">
                 <group name="kpi_x_job_order" string="KPIs Description">
                     <field name="kpi_x_job_order" nolabel="1" colspan="2">
-                        <tree editable="bottom" create="0" delete="0">
+                        <tree editable="bottom">
                             <field name="analytic_account_id" invisible="1" />
+                            <field name="mis_report_id" invisible="1" />
                             <field
-                                name="kpi_ids"
+                                name="job_order_ids"
                                 force_save="1"
                                 widget="many2many_tags"
                                 options="{'no_open': True, 'no_create': True}"
                             />
                             <field
-                                name="job_order_ids"
+                                name="kpi_ids"
                                 widget="many2many_tags"
                                 options="{'no_open': True, 'no_create': True}"
                             />


### PR DESCRIPTION
- Change date to on wizard update consumed to last date of the year
- Change compute budget control plan with KPIs
- Change selected Job Order before KPIs
- Fix KPIs in kpi_x_job_order can selected with budgetable only
- Add job sequence for filter KPIs with same name