### PR TITLE
[14.0][IMP] All budget.docline.mixin document, add date_commit

### DIFF
--- a/budget_control/models/base_budget_move.py
+++ b/budget_control/models/base_budget_move.py
@@ -89,6 +89,11 @@ class BudgetDoclineMixin(models.AbstractModel):
         copy=False,
         readonly=False,  # Allow manual entry of this field
     )
+    auto_adjust_date_commit = fields.Boolean(
+        string="Auto Adjust Date Commit",
+        compute="_compute_auto_adjust_date_commit",
+        readonly=True,
+    )
 
     def _budget_model(self):
         return (
@@ -104,6 +109,13 @@ class BudgetDoclineMixin(models.AbstractModel):
 
     def _valid_commit_state(self):
         raise ValidationError(_("No implementation error!"))
+
+    @api.depends(lambda self: [self._budget_analytic_field])
+    def _compute_auto_adjust_date_commit(self):
+        for docline in self:
+            docline.auto_adjust_date_commit = docline[
+                self._budget_analytic_field
+            ].auto_adjust_date_commit
 
     @api.depends()
     def _compute_can_commit(self):

--- a/budget_control/views/account_move_views.xml
+++ b/budget_control/views/account_move_views.xml
@@ -11,6 +11,13 @@
                     attrs="{'invisible':[('move_type', 'in', ('in_invoice', 'in_receipt', 'in_refund', 'out_invoice', 'out_refund'))]}"
                 />
             </xpath>
+            <xpath
+                expr="//page[@id='invoice_tab']/field[@name='invoice_line_ids']/tree/field[last()]"
+                position="after"
+            >
+                <field name="auto_adjust_date_commit" optional="hide" />
+                <field name="date_commit" optional="hide" />
+            </xpath>
             <xpath expr="/form/sheet/notebook/page[last()]" position="after">
                 <page
                     string="Budget Commitment"

--- a/budget_control_expense/views/hr_expense_view.xml
+++ b/budget_control_expense/views/hr_expense_view.xml
@@ -15,6 +15,17 @@
         <field name="model">hr.expense.sheet</field>
         <field name="inherit_id" ref="hr_expense.view_hr_expense_sheet_form" />
         <field name="arch" type="xml">
+            <xpath
+                expr="//page[@name='expenses']/field[@name='expense_line_ids']/tree/field[last()]"
+                position="after"
+            >
+                <field name="auto_adjust_date_commit" optional="hide" />
+                <field
+                    name="date_commit"
+                    optional="hide"
+                    attrs="{'readonly': [('state', '!=', 'draft')]}"
+                />
+            </xpath>
             <xpath expr="/form/sheet/notebook/page[last()]" position="after">
                 <page
                     string="Budget Commitment"

--- a/budget_control_purchase/views/purchase_view.xml
+++ b/budget_control_purchase/views/purchase_view.xml
@@ -17,6 +17,17 @@
             >
                 <attribute name="optional">show</attribute>
             </xpath>
+            <xpath
+                expr="//page[@name='products']/field[@name='order_line']/tree/field[last()]"
+                position="after"
+            >
+                <field name="auto_adjust_date_commit" optional="hide" />
+                <field
+                    name="date_commit"
+                    optional="hide"
+                    attrs="{'readonly': [('state', '!=', 'draft')]}"
+                />
+            </xpath>
             <xpath expr="/form/sheet/notebook/page[last()]" position="after">
                 <page
                     string="Budget Commitment"

--- a/budget_control_purchase_request/views/purchase_request_view.xml
+++ b/budget_control_purchase_request/views/purchase_request_view.xml
@@ -5,6 +5,14 @@
         <field name="model">purchase.request</field>
         <field name="inherit_id" ref="purchase_request.view_purchase_request_form" />
         <field name="arch" type="xml">
+            <xpath
+                expr="//page/field[@name='line_ids']/tree/field[last()]"
+                position="after"
+            >
+                <field name="auto_adjust_date_commit" optional="hide" />
+                <field name="date_commit" optional="hide" />
+            </xpath>
+
             <xpath expr="/form/sheet/notebook/page[last()]" position="after">
                 <page
                     string="Budget Commitment"


### PR DESCRIPTION
Add `date_commit` (editable) and `auto_adjust_date_commit` in all budget document. PR/PO/EX/INV

Also tested that, the date_commit works well with auto_adjust_date_commit.

![Selection_310](https://user-images.githubusercontent.com/1973598/120463642-52801a00-c3c6-11eb-8074-55a0b83df08d.png)
