### PR TITLE
ENH, create budget.docline.mixin.base, to used for non budgeting model

### DIFF
--- a/budget_activity/models/base_budget_move.py
+++ b/budget_activity/models/base_budget_move.py
@@ -28,14 +28,18 @@ class BaseBudgetMove(models.AbstractModel):
                 )
 
 
-class BudgetDoclineMixin(models.AbstractModel):
-    _inherit = "budget.docline.mixin"
+class BudgetDoclineMixinBase(models.AbstractModel):
+    _inherit = "budget.docline.mixin.base"
 
     activity_id = fields.Many2one(
         comodel_name="budget.activity",
         string="Activity",
         index=True,
     )
+
+
+class BudgetDoclineMixin(models.AbstractModel):
+    _inherit = "budget.docline.mixin"
 
     def _update_budget_commitment(self, budget_vals, reverse=False):
         budget_vals = super()._update_budget_commitment(

--- a/budget_allocation_dimension/models/base_budget_move.py
+++ b/budget_allocation_dimension/models/base_budget_move.py
@@ -35,8 +35,8 @@ class BaseBudgetMove(models.AbstractModel):
         )
 
 
-class BudgetDoclineMixin(models.AbstractModel):
-    _inherit = "budget.docline.mixin"
+class BudgetDoclineMixinBase(models.AbstractModel):
+    _inherit = "budget.docline.mixin.base"
 
     analytic_tag_all = fields.Many2many(
         comodel_name="account.analytic.tag",
@@ -46,21 +46,20 @@ class BudgetDoclineMixin(models.AbstractModel):
 
     @api.onchange("analytic_tag_all")
     def _onchange_analytic_tag_all(self):
-        for doc in self:
-            dimension_fields = doc._get_dimension_fields()
-            analytic_tag_ids = doc[
-                doc._budget_analytic_field
-            ].allocation_line_ids.mapped(doc._analytic_tag_field_name)
-            if (
-                len(analytic_tag_ids) != len(dimension_fields)
-                and doc.analytic_tag_ids
-            ):
-                continue
-            doc.analytic_tag_ids = (
-                len(analytic_tag_ids) == len(dimension_fields)
-                and analytic_tag_ids
-                or False
-            )
+        dimension_fields = self._get_dimension_fields()
+        analytic_tag_ids = self[
+            self._budget_analytic_field
+        ].allocation_line_ids.mapped(self._analytic_tag_field_name)
+        if (
+            len(analytic_tag_ids) != len(dimension_fields)
+            and self.analytic_tag_ids
+        ):
+            return
+        self.analytic_tag_ids = (
+            len(analytic_tag_ids) == len(dimension_fields)
+            and analytic_tag_ids
+            or False
+        )
 
     def _get_dimension_fields(self):
         if self.env.context.get("update_custom_fields"):

--- a/budget_allocation_fund/models/base_budget_move.py
+++ b/budget_allocation_fund/models/base_budget_move.py
@@ -26,8 +26,8 @@ class BaseBudgetMove(models.AbstractModel):
         return " and ".join([where_query, where_fund])
 
 
-class BudgetDoclineMixin(models.AbstractModel):
-    _inherit = "budget.docline.mixin"
+class BudgetDoclineMixinBase(models.AbstractModel):
+    _inherit = "budget.docline.mixin.base"
 
     fund_id = fields.Many2one(
         comodel_name="budget.source.fund",
@@ -58,6 +58,10 @@ class BudgetDoclineMixin(models.AbstractModel):
             doc.fund_all = doc[
                 doc._budget_analytic_field
             ].allocation_line_ids.mapped("fund_id")
+
+
+class BudgetDoclineMixin(models.AbstractModel):
+    _inherit = "budget.docline.mixin"
 
     def _update_budget_commitment(self, budget_vals, reverse=False):
         budget_vals = super()._update_budget_commitment(

--- a/budget_control/models/base_budget_move.py
+++ b/budget_control/models/base_budget_move.py
@@ -64,11 +64,13 @@ class BaseBudgetMove(models.AbstractModel):
     )
 
 
-class BudgetDoclineMixin(models.AbstractModel):
-    _name = "budget.docline.mixin"
-    _description = "Mixin used in each document line model that commit budget"
-    # Budget related variables
+class BudgetDoclineMixinBase(models.AbstractModel):
+    _name = "budget.docline.mixin.base"
+    _description = (
+        "Base of budget.docline.mixin, used for non budgeting model extension"
+    )
     _budget_analytic_field = "analytic_account_id"
+    # Budget related variables
     _budget_date_commit_fields = []  # Date used for budget commitment
     _budget_move_model = False  # account.budget.move
     _budget_move_field = "budget_move_ids"
@@ -78,6 +80,12 @@ class BudgetDoclineMixin(models.AbstractModel):
         "cancel",
         "rejected",
     ]  # Never set date commit states
+
+
+class BudgetDoclineMixin(models.AbstractModel):
+    _name = "budget.docline.mixin"
+    _inherit = ["budget.docline.mixin.base"]
+    _description = "Mixin used in each document line model that commit budget"
 
     can_commit = fields.Boolean(
         compute="_compute_can_commit",

--- a/budget_job_order/models/base_budget_move.py
+++ b/budget_job_order/models/base_budget_move.py
@@ -14,8 +14,8 @@ class BaseBudgetMove(models.AbstractModel):
     )
 
 
-class BudgetDoclineMixin(models.AbstractModel):
-    _inherit = "budget.docline.mixin"
+class BudgetDoclineMixinBase(models.AbstractModel):
+    _inherit = "budget.docline.mixin.base"
 
     job_order_id = fields.Many2one(
         comodel_name="budget.job.order",
@@ -23,6 +23,10 @@ class BudgetDoclineMixin(models.AbstractModel):
         index=True,
         ondelete="restrict",
     )
+
+
+class BudgetDoclineMixin(models.AbstractModel):
+    _inherit = "budget.docline.mixin"
 
     def _update_budget_commitment(self, budget_vals, reverse=False):
         budget_vals = super()._update_budget_commitment(


### PR DESCRIPTION
This ENH should not affect any functionality. I just want to split `budget.docline.mixin.base` from `budget.docline.mixin`

I need those additional field, i.e., fund_id, job_order_id, activity_id, for non-budgeting model like request.request.

cc @Saran440 please review/help test this (I didn't test much yet).