### PR TITLE
IMP, budget_activity_advance_clearing, add clearing_activity_id

### DIFF
--- a/budget_activity_advance_clearing/views/hr_expense_view.xml
+++ b/budget_activity_advance_clearing/views/hr_expense_view.xml
@@ -10,6 +10,13 @@
                     {'invisible': [('advance', '=', True)]}
                 </attribute>
             </xpath>
+            <field name="product_id" position="after">
+                <field
+                    name="clearing_activity_id"
+                    attrs="{'invisible': [('advance', '=', False)]}"
+                    placeholder="Optional clearing activity is used during clear advance"
+                />
+            </field>
         </field>
     </record>
 </odoo>


### PR DESCRIPTION
Added clearing activity for advance case. And this activity will be used when Clear advance (like clearing_product_id)

![Selection_187](https://user-images.githubusercontent.com/1973598/139800589-6787febf-0d8b-46a3-8358-d8fa7d48cf7b.png)
