### PR TITLE
[FIX] case clearing advance button send name

### DIFF
--- a/budget_activity_advance_clearing/models/hr_expense.py
+++ b/budget_activity_advance_clearing/models/hr_expense.py
@@ -34,6 +34,7 @@ class HRExpenseSheet(models.Model):
         ):
             clear_advance = self._prepare_clear_advance(line)
             clear_advance["activity_id"] = line.clearing_activity_id.id
+            clear_advance["name"] = line.clearing_activity_id.name
             clearing_line = Expense.new(clear_advance)
             clearing_line._onchange_activity_id()
             self.expense_line_ids += clearing_line

--- a/budget_activity_advance_clearing/views/hr_expense_view.xml
+++ b/budget_activity_advance_clearing/views/hr_expense_view.xml
@@ -13,7 +13,7 @@
             <field name="activity_id" position="attributes">
                 <attribute
                     name="attrs"
-                >{'readonly': [('advance', '=', True)]}</attribute>
+                >{'readonly': ['|', ('advance', '=', True), ('state', 'in', ['approve', 'post', 'done'])]}</attribute>
                 <attribute name="force_save">1</attribute>
             </field>
             <field name="activity_id" position="after">

--- a/budget_control_advance_clearing/views/hr_expense_view.xml
+++ b/budget_control_advance_clearing/views/hr_expense_view.xml
@@ -13,11 +13,13 @@
                 <attribute name="attrs">
                     {'readonly': [('is_editable', '=', False)]}
                 </attribute>
+                <attribute name="force_save">1</attribute>
             </field>
             <field name="analytic_tag_ids" position="attributes">
                 <attribute name="attrs">
                     {'readonly': [('is_editable', '=', False)]}
                 </attribute>
+                <attribute name="force_save">1</attribute>
             </field>
         </field>
     </record>


### PR DESCRIPTION
Standard Budget activity advance clearing

- Clearing Product + Clearing Activity --> Pass
- Clearing Product only -> Pass
- Clearing Activity only -> Wrong description (required)

Step to error
1. Create AV and select clearing activity
![Selection_001](https://user-images.githubusercontent.com/20896369/141908304-d8bb0ddc-1adf-403f-869d-7b0903be2e3c.png)
2. Normal process advance
3. Click **Clear Advance** > create name report > save
![Selection_002](https://user-images.githubusercontent.com/20896369/141909667-c70f2d18-4e35-4d23-992b-2343e63393ce.png)

Fix
- send name from activity into name on hr.expense

**Warning**: Product is null but you can process normal

- [ ] depdends on - https://github.com/OCA/hr-expense/pull/79

cc @kittiu 