### PR TITLE
[14.0][FIX] dimension_tag_required skip if not affect budget

### DIFF
--- a/account_asset_fund/models/account_asset.py
+++ b/account_asset_fund/models/account_asset.py
@@ -29,13 +29,14 @@ class AccountAsset(models.Model):
     def _compute_fund_all(self):
         SourceFund = self.env["budget.source.fund"]
         source_fund_all = SourceFund.search([])
+        allocation_line = hasattr(
+            self.env["account.analytic.account"], "allocation_line_ids"
+        )
+        allocation_line_fund = hasattr(self.env["budget.allocation.line"], "fund_id")
         for rec in self:
-            field_allocation_line = rec.account_analytic_id._fields.get(
-                "allocation_line_ids"
-            )
             # show all fund, when not install 'budget_allocation_fund' module
             rec.fund_all = (
-                field_allocation_line
-                and rec.account_analytic_id.allocation_line_ids.mapped("fund_id")
-                or source_fund_all
+                rec.account_analytic_id.allocation_line_ids.mapped("fund_id")
+                if allocation_line and allocation_line_fund
+                else source_fund_all
             )

--- a/account_asset_fund/models/account_asset.py
+++ b/account_asset_fund/models/account_asset.py
@@ -7,6 +7,7 @@ from odoo import api, fields, models
 class AccountAsset(models.Model):
     _inherit = "account.asset"
 
+    not_affect_budget = fields.Boolean(default=True)
     fund_id = fields.Many2one(
         comodel_name="budget.source.fund",
         index=True,

--- a/account_asset_fund/models/account_asset_line.py
+++ b/account_asset_fund/models/account_asset_line.py
@@ -7,6 +7,12 @@ from odoo import models
 class AccountAssetLine(models.Model):
     _inherit = "account.asset.line"
 
+    def _setup_move_data(self, depreciation_date):
+        """Users can config account.move affect budget"""
+        move_data = super()._setup_move_data(depreciation_date)
+        move_data["not_affect_budget"] = self.asset_id.not_affect_budget
+        return move_data
+
     def _setup_move_line_data(self, depreciation_date, account, ml_type, move):
         move_line_data = super()._setup_move_line_data(
             depreciation_date, account, ml_type, move

--- a/account_asset_fund/views/account_asset.xml
+++ b/account_asset_fund/views/account_asset.xml
@@ -8,15 +8,14 @@
             ref="account_asset_management.account_asset_view_form"
         />
         <field name="arch" type="xml">
-            <xpath expr="//notebook" position="inside">
-                <field name="fund_all" widget="many2many_tags" />
-            </xpath>
             <xpath expr="//field[@name='analytic_tag_ids']" position="after">
                 <field
                     name="fund_id"
                     options="{'no_create': True}"
                     domain="[('id', 'in', fund_all)]"
                 />
+                <field name="fund_all" widget="many2many_tags" invisible="1" />
+                <field name="not_affect_budget" />
 
             </xpath>
         </field>

--- a/account_asset_transfer_allocation_dimension/wizard/account_asset_transfer.py
+++ b/account_asset_transfer_allocation_dimension/wizard/account_asset_transfer.py
@@ -1,7 +1,18 @@
 # Copyright 2021 Ecosoft Co., Ltd. (http://ecosoft.co.th)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import models
+from odoo import fields, models
+
+
+class AccountAssetTransfer(models.TransientModel):
+    _inherit = "account.asset.transfer"
+
+    not_affect_budget = fields.Boolean(default=True)
+
+    def _get_new_move_transfer(self):
+        move_data = super()._get_new_move_transfer()
+        move_data["not_affect_budget"] = self.not_affect_budget
+        return move_data
 
 
 class AccountAssetTransferLine(models.TransientModel):

--- a/account_asset_transfer_allocation_dimension/wizard/account_asset_transfer.xml
+++ b/account_asset_transfer_allocation_dimension/wizard/account_asset_transfer.xml
@@ -8,6 +8,9 @@
             ref="account_asset_transfer.account_asset_transfer_view_form"
         />
         <field name="arch" type="xml">
+            <xpath expr="//group/field[@name='analytic_tag_ids']" position="after">
+                <field name="not_affect_budget" />
+            </xpath>
             <xpath
                 expr="//field[@name='to_asset_ids']/tree/field[@name='analytic_tag_ids']"
                 position="after"

--- a/budget_allocation_dimension/models/__init__.py
+++ b/budget_allocation_dimension/models/__init__.py
@@ -8,3 +8,4 @@ from . import budget_control
 from . import budget_move_adjustment
 from . import mis_report_instance
 from . import budget_transfer_item
+from . import account_analytic_tag

--- a/budget_allocation_dimension/models/account_analytic_tag.py
+++ b/budget_allocation_dimension/models/account_analytic_tag.py
@@ -16,7 +16,7 @@ class AccountAnalyticTag(models.Model):
         elif record._name == "account.analytic.line":
             not_affect_budget = record.move_id.move_id.not_affect_budget
         # field has analytic account, check control_budget in budget_period
-        elif hasattr(record, "_budget_analytic_field"):
+        if hasattr(record, "_budget_analytic_field"):
             date = record[record._budget_analytic_field].bm_date_to
             period = self.env["budget.period"]._get_eligible_budget_period(date)
             if not period.control_budget:

--- a/budget_allocation_dimension/models/account_analytic_tag.py
+++ b/budget_allocation_dimension/models/account_analytic_tag.py
@@ -1,0 +1,27 @@
+# Copyright 2022 Ecosoft Co., Ltd (http://ecosoft.co.th/)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html)
+
+from odoo import models
+
+
+class AccountAnalyticTag(models.Model):
+    _inherit = "account.analytic.tag"
+
+    def _check_required_dimension(self, record):
+        """Skip check dimension if not affect budget and period budget is not control"""
+        record.ensure_one()
+        not_affect_budget = False
+        if record._name == "account.move.line":
+            not_affect_budget = record.move_id.not_affect_budget
+        elif record._name == "account.analytic.line":
+            not_affect_budget = record.move_id.move_id.not_affect_budget
+        # field has analytic account, check control_budget in budget_period
+        elif hasattr(record, "_budget_analytic_field"):
+            date = record[record._budget_analytic_field].bm_date_to
+            period = self.env["budget.period"]._get_eligible_budget_period(date)
+            if not period.control_budget:
+                not_affect_budget = True
+        # not affect budget = not check dimension
+        if not_affect_budget:
+            return
+        return super()._check_required_dimension(record)

--- a/budget_allocation_dimension_purchase_requisition/wizard/purchase_request_line_make_purchase_requisition.py
+++ b/budget_allocation_dimension_purchase_requisition/wizard/purchase_request_line_make_purchase_requisition.py
@@ -11,5 +11,7 @@ class PurchaseRequestLineMakePurchaseRequisition(models.TransientModel):
     def _prepare_purchase_requisition_line(self, pr, item):
         """Convert analytic_tags from [1,2,3] to [6, 0, [1,2,3]]"""
         pr_line_dict = super()._prepare_purchase_requisition_line(pr, item)
-        pr_line_dict["analytic_tag_ids"] = [(6, 0, pr_line_dict["analytic_tag_ids"] or [])]
+        pr_line_dict["analytic_tag_ids"] = [
+            (6, 0, pr_line_dict["analytic_tag_ids"] or [])
+        ]
         return pr_line_dict

--- a/budget_source_fund/models/base_budget_move.py
+++ b/budget_source_fund/models/base_budget_move.py
@@ -49,14 +49,17 @@ class BudgetDoclineMixinBase(models.AbstractModel):
         source_fund_all = SourceFund.search([])
         for doc in self:
             budget_analytic_fields = doc[doc._budget_analytic_field]
-            field_allocation_line = budget_analytic_fields._fields.get(
-                "allocation_line_ids"
+            allocation_line = hasattr(
+                self.env["account.analytic.account"], "allocation_line_ids"
+            )
+            allocation_line_fund = hasattr(
+                self.env["budget.allocation.line"], "fund_id"
             )
             # show all fund, when not install 'budget_allocation_fund' module
             doc.fund_all = (
-                field_allocation_line
-                and budget_analytic_fields.allocation_line_ids.mapped("fund_id")
-                or source_fund_all
+                budget_analytic_fields.allocation_line_ids.mapped("fund_id")
+                if allocation_line and allocation_line_fund
+                else source_fund_all
             )
 
 


### PR DESCRIPTION
1. Add not_affect_budget at asset - it will send it when create_move at depreciation board
![Selection_001](https://user-images.githubusercontent.com/20896369/219625517-66c3706d-b378-4dd5-a9c7-7287b764d5bb.png)

2. Add not_affect_budget at asset transfer
![Selection_002](https://user-images.githubusercontent.com/20896369/219625496-8ce1fcad-712d-4ab3-8e0f-61dda225f14d.png)


All image is capture from v15
cc: @newtratip 