### PR TITLE
[14.0][FIX] constraint with analytic revision

### DIFF
--- a/budget_control_revision/models/budget_control.py
+++ b/budget_control_revision/models/budget_control.py
@@ -22,11 +22,11 @@ class BudgetControl(models.Model):
     revision_number = fields.Integer(readonly=True)
     enable_revision_number = fields.Boolean(compute="_compute_group_revision_number")
 
-    # Add budget_period_id for check constrains
+    # Add budget_period_id and analytic account for check constrains
     _sql_constraints = [
         (
             "revision_unique",
-            "unique(unrevisioned_name, revision_number, budget_period_id)",
+            "unique(unrevisioned_name, revision_number, budget_period_id, analytic_account_id)",
             "Reference and revision must be unique.",
         )
     ]


### PR DESCRIPTION
Step to error

1. Create analytic name "A1"
2. Normal step budget allocation -> budget plan -> budget control
3. Change name analytic to "A2"
4. Create new analytic name "A1"
5. Go to Budget Allocation -> Add new analytic A1 and normal process
6. When you Create/Update Budget Control, it will error because unrevisioned_name still use old name

This PR add constraint for check analytic account too
So, unrevisioned_name will duplicate but analytic account is new