### PR TITLE
[FIX] budget_control: error no date on convert currency amount

### DIFF
--- a/budget_control/models/base_budget_move.py
+++ b/budget_control/models/base_budget_move.py
@@ -309,18 +309,18 @@ class BudgetDoclineMixin(models.AbstractModel):
         )
         currency = hasattr(self, "currency_id") and self.currency_id or False
         amount = budget_vals["amount_currency"]  # init
+        today = fields.Date.context_today(self)
         if (
             not self.env.context.get("use_amount_commit")
             and currency
             and currency != company.currency_id
         ):
             amount = self._get_amount_convert_currency(
-                budget_vals["amount_currency"], currency, company, date_commit
+                budget_vals["amount_currency"], currency, company, date_commit or today
             )
         # By default, commit date is equal to document date
         # this is correct for normal case, but may require different date
         # in case of budget that carried to new period/year
-        today = fields.Date.context_today(self)
         res = {
             "product_id": self.product_id.id,
             "account_id": account.id,


### PR DESCRIPTION
**Error message:**

Traceback (most recent call last):
  File "/opt/odoo/custom/src/odoo/odoo/addons/base/models/ir_http.py", line 237, in _dispatch
    result = request.dispatch()
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 698, in dispatch
    result = self._call_function(**self.params)
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 368, in _call_function
    return checked_call(self.db, *args, **kwargs)
  File "/opt/odoo/custom/src/odoo/odoo/service/model.py", line 94, in wrapper
    return f(dbname, *args, **kwargs)
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 357, in checked_call
    result = self.endpoint(*a, **kw)
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 921, in __call__
    return self.method(*args, **kw)
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 546, in response_wrap
    response = f(*args, **kw)
  File "/opt/odoo/auto/addons/web/controllers/main.py", line 1328, in call_button
    action = self._call_kw(model, method, args, kwargs)
  File "/opt/odoo/auto/addons/web/controllers/main.py", line 1316, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "/opt/odoo/custom/src/odoo/odoo/api.py", line 469, in call_kw
    result = _call_kw_multi(method, model, args, kwargs)
  File "/opt/odoo/custom/src/odoo/odoo/api.py", line 456, in _call_kw_multi
    result = method(recs, *args, **kwargs)
  File "/opt/odoo/auto/addons/budget_control_expense/models/hr_expense.py", line 54, in action_sheet_move_create
    res = super().action_sheet_move_create()
  File "/opt/odoo/auto/addons/hr_expense_pay_to_vendor/models/hr_expense.py", line 94, in action_sheet_move_create
    res = super().action_sheet_move_create()
  File "/opt/odoo/auto/addons/hr_expense_cancel_confirm/model/hr_expense.py", line 22, in action_sheet_move_create
    return super().action_sheet_move_create()
  File "/opt/odoo/auto/addons/hr_expense_advance_clearing/models/hr_expense_sheet.py", line 108, in action_sheet_move_create
    res = super().action_sheet_move_create()
  File "/opt/odoo/auto/addons/hr_expense/models/hr_expense.py", line 1056, in action_sheet_move_create
    res = expense_line_ids.with_context(clean_context(self.env.context)).action_move_create()
  File "/opt/odoo/auto/addons/hr_expense/models/hr_expense.py", line 646, in action_move_create
    move._post()
  File "/opt/odoo/auto/addons/l10n_th_account_tax_expense/models/account_move.py", line 13, in _post
    res = super()._post(soft)
  File "/opt/odoo/auto/addons/jvc_account/model/account_move.py", line 32, in _post
    res = super()._post(soft)
  File "/opt/odoo/auto/addons/stock_account/models/account_move.py", line 53, in _post
    posted = super()._post(soft)
  File "/opt/odoo/auto/addons/l10n_th_account_tax/models/account_move.py", line 428, in _post
    res = super()._post(soft=soft)
  File "/opt/odoo/auto/addons/hr_expense/models/account_move.py", line 25, in _post
    return super()._post(soft)
  File "/opt/odoo/auto/addons/account_edi/models/account_move.py", line 502, in _post
    posted = super()._post(soft=soft)
  File "/opt/odoo/auto/addons/account/models/account_move.py", line 3141, in _post
    to_post.write({
  File "/opt/odoo/auto/addons/budget_control_expense/models/account_move.py", line 14, in write
    self.mapped("line_ids.expense_id").recompute_budget_move()
  File "/opt/odoo/auto/addons/budget_control_advance_clearing/models/hr_expense.py", line 152, in recompute_budget_move
    res = super(HRExpense, expenses).recompute_budget_move()
  File "/opt/odoo/auto/addons/budget_control_expense/models/hr_expense.py", line 84, in recompute_budget_move
    move_lines.uncommit_expense_budget()
  File "/opt/odoo/auto/addons/budget_control_expense/models/account_move_line.py", line 38, in uncommit_expense_budget
    expense.commit_budget(
  File "/opt/odoo/auto/addons/budget_control_advance_clearing/models/hr_expense.py", line 178, in commit_budget
    return super().commit_budget(reverse=reverse, **vals)
  File "/opt/odoo/auto/addons/budget_control/models/base_budget_move.py", line 470, in commit_budget
    budget_vals = self._update_budget_commitment(budget_vals, reverse=reverse)
  File "/opt/odoo/auto/addons/budget_control/models/base_budget_move.py", line 317, in _update_budget_commitment
    amount = self._get_amount_convert_currency(
  File "/opt/odoo/auto/addons/budget_control/models/base_budget_move.py", line 293, in _get_amount_convert_currency
    return currency._convert(
  File "/opt/odoo/custom/src/odoo/odoo/addons/base/models/res_currency.py", line 268, in _convert
    assert date, "convert amount from unknown date"
Exception

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 654, in _handle_exception
    return super(JsonRequest, self)._handle_exception(exception)
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 301, in _handle_exception
    raise exception.with_traceback(None) from new_cause
AssertionError: convert amount from unknown date