### PR TITLE
[16.0][FIX] budget_control_expense: recompute after unlink

### DIFF
--- a/budget_control_advance_clearing/models/hr_expense.py
+++ b/budget_control_advance_clearing/models/hr_expense.py
@@ -47,6 +47,13 @@ class HRExpenseSheet(models.Model):
             res["not_affect_budget"] = True
         return res
 
+    def unlink(self):
+        # Recompute budget advance after unlink
+        advance = self.advance_sheet_id
+        res = super().unlink()
+        advance.recompute_budget_move()
+        return res
+
 
 class HRExpense(models.Model):
     _inherit = "hr.expense"

--- a/budget_control_advance_clearing/tests/test_budget_advance.py
+++ b/budget_control_advance_clearing/tests/test_budget_advance.py
@@ -188,7 +188,7 @@ class TestBudgetControlAdvance(BudgetControlCommon):
         self.assertEqual(self.budget_control.amount_advance, 100)
         self.assertEqual(self.budget_control.amount_expense, 0)
         self.assertEqual(self.budget_control.amount_balance, 200)
-        # Create Clearing = 80 to this advance
+        # Create Total Clearing = 80 to this advance
         clearing = self._create_clearing_sheet(
             advance,
             [
@@ -199,7 +199,7 @@ class TestBudgetControlAdvance(BudgetControlCommon):
                     "analytic_distribution": analytic_distribution,
                 },
                 {
-                    "product_id": self.product2,  # KPI2 = 80
+                    "product_id": self.product2,  # KPI2 = 60
                     "product_qty": 2,
                     "price_unit": 30,
                     "analytic_distribution": analytic_distribution,
@@ -224,6 +224,16 @@ class TestBudgetControlAdvance(BudgetControlCommon):
         clearing.expense_line_ids[:1].total_amount = 290
         with self.assertRaises(UserError):
             clearing.action_submit_sheet()
+
+        # (5) Delete Clearing, Advance should be uncommitted
+        clearing.expense_line_ids[:1].total_amount = 50
+        clearing.action_submit_sheet()
+        clearing.approve_expense_sheets()
+        self.assertEqual(
+            self.budget_control.amount_advance, 30
+        )  # total is 100 - (50 + 20)
+        clearing.unlink()
+        self.assertEqual(self.budget_control.amount_advance, 100)
 
     @freeze_time("2001-02-01")
     def test_03_budget_recompute_and_close_budget_move(self):

--- a/budget_control_expense/models/expense_budget_move.py
+++ b/budget_control_expense/models/expense_budget_move.py
@@ -21,6 +21,7 @@ class ExpenseBudgetMove(models.Model):
         readonly=True,
         store=True,
         index=True,
+        ondelete="cascade",
     )
     move_id = fields.Many2one(
         comodel_name="account.move",

--- a/budget_control_expense/models/hr_expense.py
+++ b/budget_control_expense/models/hr_expense.py
@@ -34,6 +34,13 @@ class HRExpenseSheet(models.Model):
             doclines.recompute_budget_move()
         return res
 
+    def unlink(self):
+        # Compute commit again after unlink
+        expenses = self.mapped("expense_line_ids")
+        res = super().unlink()
+        expenses._compute_commit()
+        return res
+
     def approve_expense_sheets(self):
         res = super().approve_expense_sheets()
         BudgetPeriod = self.env["budget.period"]

--- a/budget_control_expense/tests/test_budget_expense.py
+++ b/budget_control_expense/tests/test_budget_expense.py
@@ -42,9 +42,6 @@ class TestBudgetControlExpense(BudgetControlCommon):
         cls.budget_control.line_ids.filtered(lambda x: x.kpi_id == cls.kpi2)[:1].write(
             {"amount": 200}
         )
-        # cls.budget_control.flush_model()  # Need to flush data into table, so it can be sql
-        # cls.budget_control.allocated_amount = 300
-        # cls.budget_control.action_done()
 
     @freeze_time("2001-02-01")
     def _create_expense_sheet(self, ex_lines):
@@ -127,6 +124,13 @@ class TestBudgetControlExpense(BudgetControlCommon):
         # CostCenter1, will result in $ -1.00
         with self.assertRaises(UserError):
             expense.action_submit_sheet()
+        # (5) Delete Expense Sheet
+        expense.expense_line_ids.write({"total_amount": 100})
+        expense.action_submit_sheet()
+        expense.approve_expense_sheets()
+        self.assertEqual(self.budget_control.amount_balance, 100)  # 2 lines
+        expense.unlink()
+        self.assertEqual(self.budget_control.amount_balance, 300)
 
     @freeze_time("2001-02-01")
     def test_02_budget_expense_to_journal_posting(self):


### PR DESCRIPTION
Cherry-pick from https://github.com/ecosoft-odoo/budgeting/pull/450