### PR TITLE
[15.0][FIX] budget_*: change sequence to 2 digits

### DIFF
--- a/budget_allocation/models/base_budget_move.py
+++ b/budget_allocation/models/base_budget_move.py
@@ -115,7 +115,7 @@ class BaseBudgetMove(models.AbstractModel):
             fund_name = docline.fund_id.name
             tag_name = ", ".join(docline.analytic_tag_ids.mapped("name"))
             query_dict = self._get_query_dict(docline)
-            if not any(x["amount_type"] == "1_budget" for x in query_dict):
+            if not any(x["amount_type"] == "10_budget" for x in query_dict):
                 errors.append(
                     _(
                         "%(name)s & %(fund_name)s & %(tag_name)s is not allocated "

--- a/budget_allocation/report/budget_source_fund_report.py
+++ b/budget_allocation/report/budget_source_fund_report.py
@@ -27,7 +27,7 @@ class SourceFundMonitorReport(models.Model):
     fund_group_id = fields.Many2one(comodel_name="budget.source.fund.group")
     amount = fields.Float()
     amount_type = fields.Selection(
-        selection=lambda self: [("1_budget", "Budget")]
+        selection=lambda self: [("10_budget", "Budget")]
         + self._get_budget_amount_type(),
         string="Type",
     )
@@ -50,7 +50,7 @@ class SourceFundMonitorReport(models.Model):
         return [
             {
                 "model": ("account.move.line", "Account Move Line"),
-                "type": ("8_actual", "Actual"),
+                "type": ("80_actual", "Actual"),
                 "budget_move": ("account_budget_move", "move_line_id"),
                 "source_doc": ("account_move", "move_id"),
             }
@@ -78,7 +78,7 @@ class SourceFundMonitorReport(models.Model):
                 formatted_dimension_fields = f", {formatted_dimension_fields}"
         for source in self._get_consumed_sources():
             res_model = source["model"][0]  # i.e., account.move.line
-            amount_type = source["type"][0]  # i.e., 8_actual
+            amount_type = source["type"][0]  # i.e., 80_actual
             res_field = source["budget_move"][1]  # i.e., move_line_id
             sql_select[amount_type] = {
                 0: """
@@ -97,7 +97,7 @@ class SourceFundMonitorReport(models.Model):
                 1::boolean as active %s
                 """
                 % (
-                    amount_type[:1],
+                    amount_type[:2],
                     res_model,
                     res_field,
                     amount_type,
@@ -110,7 +110,7 @@ class SourceFundMonitorReport(models.Model):
         sql_from = {}
         for source in self._get_consumed_sources():
             budget_table = source["budget_move"][0]  # i.e., account_budget_move
-            amount_type = source["type"][0]  # i.e., 8_actual
+            amount_type = source["type"][0]  # i.e., 80_actual
             sql_from[
                 amount_type
             ] = """
@@ -141,7 +141,7 @@ class SourceFundMonitorReport(models.Model):
             sf.id as fund_id,
             sf_group.id as fund_group_id,
             aa.id as analytic_account_id,
-            '1_budget' as amount_type,
+            '10_budget' as amount_type,
             al.released_amount as amount,
             bp.bm_date_from as date_from,
             bp.bm_date_to as date_to,
@@ -188,7 +188,7 @@ class SourceFundMonitorReport(models.Model):
             select_budget_query[x] for x in key_select_budget_list
         )
         # commitment
-        select_actual_query = self._select_statement("8_actual")
+        select_actual_query = self._select_statement("80_actual")
         key_select_actual_list = sorted(select_budget_query.keys())
         select_actual = ", ".join(
             select_actual_query[x] for x in key_select_actual_list
@@ -198,7 +198,7 @@ class SourceFundMonitorReport(models.Model):
             self._from_budget(),
             self._where_budget(),
             select_actual,
-            self._from_statement("8_actual"),
+            self._from_statement("80_actual"),
             self._where_actual(),
         )
 

--- a/budget_allocation_advance_clearing/report/budget_source_fund_report.py
+++ b/budget_allocation_advance_clearing/report/budget_source_fund_report.py
@@ -11,17 +11,17 @@ class SourceFundMonitorReport(models.Model):
         return super()._get_consumed_sources() + [
             {
                 "model": ("hr.expense", "Expense"),
-                "type": ("4_av_commit", "AV Commit"),
+                "type": ("40_av_commit", "AV Commit"),
                 "budget_move": ("advance_budget_move", "expense_id"),
                 "source_doc": ("hr_expense_sheet", "sheet_id"),
             }
         ]
 
     def _get_sql(self):
-        select_av_query = self._select_statement("4_av_commit")
+        select_av_query = self._select_statement("40_av_commit")
         key_select_list = sorted(select_av_query.keys())
         select_av = ", ".join(select_av_query[x] for x in key_select_list)
         return super()._get_sql() + "union (select {} {})".format(
             select_av,
-            self._from_statement("4_av_commit"),
+            self._from_statement("40_av_commit"),
         )

--- a/budget_allocation_contract/report/budget_source_fund_report.py
+++ b/budget_allocation_contract/report/budget_source_fund_report.py
@@ -11,17 +11,17 @@ class SourceFundMonitorReport(models.Model):
         return super()._get_consumed_sources() + [
             {
                 "model": ("contract.line", "Contract Line"),
-                "type": ("6_ct_commit", "CT Commit"),
+                "type": ("60_ct_commit", "CT Commit"),
                 "budget_move": ("contract_budget_move", "contract_line_id"),
                 "source_doc": ("contract_contract", "contract_id"),
             }
         ]
 
     def _get_sql(self):
-        select_ct_query = self._select_statement("6_ct_commit")
+        select_ct_query = self._select_statement("60_ct_commit")
         key_select_list = sorted(select_ct_query.keys())
         select_ct = ", ".join(select_ct_query[x] for x in key_select_list)
         return super()._get_sql() + "union (select {} {})".format(
             select_ct,
-            self._from_statement("6_ct_commit"),
+            self._from_statement("60_ct_commit"),
         )

--- a/budget_allocation_expense/report/budget_source_fund_report.py
+++ b/budget_allocation_expense/report/budget_source_fund_report.py
@@ -11,17 +11,17 @@ class SourceFundMonitorReport(models.Model):
         return super()._get_consumed_sources() + [
             {
                 "model": ("hr.expense", "Expense"),
-                "type": ("5_ex_commit", "EX Commit"),
+                "type": ("50_ex_commit", "EX Commit"),
                 "budget_move": ("expense_budget_move", "expense_id"),
                 "source_doc": ("hr_expense_sheet", "sheet_id"),
             }
         ]
 
     def _get_sql(self):
-        select_ex_query = self._select_statement("5_ex_commit")
+        select_ex_query = self._select_statement("50_ex_commit")
         key_select_list = sorted(select_ex_query.keys())
         select_ex = ", ".join(select_ex_query[x] for x in key_select_list)
         return super()._get_sql() + "union (select {} {})".format(
             select_ex,
-            self._from_statement("5_ex_commit"),
+            self._from_statement("50_ex_commit"),
         )

--- a/budget_allocation_purchase/report/budget_source_fund_report.py
+++ b/budget_allocation_purchase/report/budget_source_fund_report.py
@@ -11,17 +11,17 @@ class SourceFundMonitorReport(models.Model):
         return super()._get_consumed_sources() + [
             {
                 "model": ("purchase.order.line", "Purchase Line"),
-                "type": ("3_po_commit", "PO Commit"),
+                "type": ("30_po_commit", "PO Commit"),
                 "budget_move": ("purchase_budget_move", "purchase_line_id"),
                 "source_doc": ("purchase_order", "purchase_id"),
             }
         ]
 
     def _get_sql(self):
-        select_po_query = self._select_statement("3_po_commit")
+        select_po_query = self._select_statement("30_po_commit")
         key_select_list = sorted(select_po_query.keys())
         select_po = ", ".join(select_po_query[x] for x in key_select_list)
         return super()._get_sql() + "union (select {} {})".format(
             select_po,
-            self._from_statement("3_po_commit"),
+            self._from_statement("30_po_commit"),
         )

--- a/budget_allocation_purchase_request/report/budget_source_fund_report.py
+++ b/budget_allocation_purchase_request/report/budget_source_fund_report.py
@@ -11,7 +11,7 @@ class SourceFundMonitorReport(models.Model):
         return super()._get_consumed_sources() + [
             {
                 "model": ("purchase.request.line", "Purchase Request Line"),
-                "type": ("2_pr_commit", "PR Commit"),
+                "type": ("20_pr_commit", "PR Commit"),
                 "budget_move": (
                     "purchase_request_budget_move",
                     "purchase_request_line_id",
@@ -21,10 +21,10 @@ class SourceFundMonitorReport(models.Model):
         ]
 
     def _get_sql(self):
-        select_pr_query = self._select_statement("2_pr_commit")
+        select_pr_query = self._select_statement("20_pr_commit")
         key_select_list = sorted(select_pr_query.keys())
         select_pr = ", ".join(select_pr_query[x] for x in key_select_list)
         return super()._get_sql() + "union (select {} {})".format(
             select_pr,
-            self._from_statement("2_pr_commit"),
+            self._from_statement("20_pr_commit"),
         )

--- a/budget_control/models/budget_control.py
+++ b/budget_control/models/budget_control.py
@@ -345,7 +345,7 @@ class BudgetControl(models.Model):
                     q["amount"]
                     for q in query_data
                     if q["amount"] is not None
-                    and q["amount_type"] not in ["1_budget", "8_actual"]
+                    and q["amount_type"] not in ["10_budget", "80_actual"]
                 )
                 line.update({"amount": abs(balance_commit)})
 

--- a/budget_control/models/budget_period.py
+++ b/budget_control/models/budget_period.py
@@ -477,7 +477,7 @@ class BudgetPeriod(models.Model):
             if is_commit:
                 budget_info[col] = -amount  # Negate
                 budget_info["amount_commit"] += budget_info[col]
-            elif amount_type == "8_actual":  # Negate consumed
+            elif amount_type == "80_actual":  # Negate consumed
                 budget_info[col] = -amount
             else:
                 budget_info[col] = amount
@@ -493,10 +493,10 @@ class BudgetPeriod(models.Model):
         query = {
             "info_cols": {
                 "amount_budget": (
-                    "1_budget",
+                    "10_budget",
                     False,
                 ),  # (amount_type, is_commit)
-                "amount_actual": ("8_actual", False),
+                "amount_actual": ("80_actual", False),
             },
             "fields": [
                 "analytic_account_id",

--- a/budget_control/report/budget_monitor_report.py
+++ b/budget_control/report/budget_monitor_report.py
@@ -31,7 +31,7 @@ class BudgetMonitorReport(models.Model):
     date = fields.Date()
     amount = fields.Float()
     amount_type = fields.Selection(
-        selection=lambda self: [("1_budget", "Budget")]
+        selection=lambda self: [("10_budget", "Budget")]
         + self._get_budget_amount_type(),
         string="Type",
     )
@@ -73,7 +73,7 @@ class BudgetMonitorReport(models.Model):
         return [
             {
                 "model": ("account.move.line", "Account Move Line"),
-                "type": ("8_actual", "Actual"),
+                "type": ("80_actual", "Actual"),
                 "budget_move": ("account_budget_move", "move_line_id"),
                 "source_doc": ("account_move", "move_id"),
             }
@@ -91,7 +91,7 @@ class BudgetMonitorReport(models.Model):
         sql_select = {}
         for source in self._get_consumed_sources():
             res_model = source["model"][0]  # i.e., account.move.line
-            amount_type = source["type"][0]  # i.e., 8_actual
+            amount_type = source["type"][0]  # i.e., 80_actual
             res_field = source["budget_move"][1]  # i.e., move_line_id
             sql_select[amount_type] = {
                 0: """
@@ -111,7 +111,7 @@ class BudgetMonitorReport(models.Model):
                 a.fwd_commit,
                 1::boolean as active
                 """
-                % (amount_type[:1], res_model, res_field, amount_type)
+                % (amount_type[:2], res_model, res_field, amount_type)
             }
         return sql_select
 
@@ -121,7 +121,7 @@ class BudgetMonitorReport(models.Model):
             budget_table = source["budget_move"][0]  # i.e., account_budget_move
             doc_table = source["source_doc"][0]  # i.e., account_move
             doc_field = source["source_doc"][1]  # i.e., move_id
-            amount_type = source["type"][0]  # i.e., 8_actual
+            amount_type = source["type"][0]  # i.e., 80_actual
             sql_from[
                 amount_type
             ] = """
@@ -143,7 +143,7 @@ class BudgetMonitorReport(models.Model):
             a.analytic_account_id,
             b.analytic_group,
             a.date_to as date,  -- approx date
-            '1_budget' as amount_type,
+            '10_budget' as amount_type,
             a.amount as amount,
             null::integer as product_id,
             null::integer as account_id,
@@ -177,7 +177,7 @@ class BudgetMonitorReport(models.Model):
         select_budget = ", ".join(
             select_budget_query[x] for x in key_select_budget_list
         )
-        select_actual_query = self._select_statement("8_actual")
+        select_actual_query = self._select_statement("80_actual")
         key_select_actual_list = sorted(select_budget_query.keys())
         select_actual = ", ".join(
             select_actual_query[x] for x in key_select_actual_list
@@ -186,7 +186,7 @@ class BudgetMonitorReport(models.Model):
             select_budget,
             self._from_budget(),
             select_actual,
-            self._from_statement("8_actual"),
+            self._from_statement("80_actual"),
             self._where_actual(),
         )
 

--- a/budget_control_advance_clearing/models/budget_period.py
+++ b/budget_control_advance_clearing/models/budget_period.py
@@ -17,7 +17,7 @@ class BudgetPeriod(models.Model):
 
     def _budget_info_query(self):
         query = super()._budget_info_query()
-        query["info_cols"]["amount_advance"] = ("4_av_commit", True)
+        query["info_cols"]["amount_advance"] = ("40_av_commit", True)
         return query
 
     @api.model

--- a/budget_control_advance_clearing/report/budget_monitor_report.py
+++ b/budget_control_advance_clearing/report/budget_monitor_report.py
@@ -11,7 +11,7 @@ class BudgetMonitorReport(models.Model):
         return super()._get_consumed_sources() + [
             {
                 "model": ("hr.expense", "Expense"),
-                "type": ("4_av_commit", "AV Commit"),
+                "type": ("40_av_commit", "AV Commit"),
                 "budget_move": ("advance_budget_move", "expense_id"),
                 "source_doc": ("hr_expense_sheet", "sheet_id"),
             }
@@ -21,11 +21,11 @@ class BudgetMonitorReport(models.Model):
         return ""
 
     def _get_sql(self):
-        select_av_query = self._select_statement("4_av_commit")
+        select_av_query = self._select_statement("40_av_commit")
         key_select_list = sorted(select_av_query.keys())
         select_av = ", ".join(select_av_query[x] for x in key_select_list)
         return super()._get_sql() + "union (select {} {} {})".format(
             select_av,
-            self._from_statement("4_av_commit"),
+            self._from_statement("40_av_commit"),
             self._where_advance_clearing(),
         )

--- a/budget_control_contract/models/budget_period.py
+++ b/budget_control_contract/models/budget_period.py
@@ -37,7 +37,7 @@ class BudgetPeriod(models.Model):
 
     def _budget_info_query(self):
         query = super()._budget_info_query()
-        query["info_cols"]["amount_contract"] = ("6_ct_commit", True)
+        query["info_cols"]["amount_contract"] = ("60_ct_commit", True)
         return query
 
     @api.depends("control_budget")

--- a/budget_control_contract/report/budget_monitor_report.py
+++ b/budget_control_contract/report/budget_monitor_report.py
@@ -10,7 +10,7 @@ class BudgetMonitorReport(models.Model):
         return super()._get_consumed_sources() + [
             {
                 "model": ("contract.line", "Contract Line"),
-                "type": ("6_ct_commit", "CT Commit"),
+                "type": ("60_ct_commit", "CT Commit"),
                 "budget_move": ("contract_budget_move", "contract_line_id"),
                 "source_doc": ("contract_contract", "contract_id"),
             }
@@ -20,11 +20,11 @@ class BudgetMonitorReport(models.Model):
         return ""
 
     def _get_sql(self):
-        select_ct_query = self._select_statement("6_ct_commit")
+        select_ct_query = self._select_statement("60_ct_commit")
         key_select_list = sorted(select_ct_query.keys())
         select_ct = ", ".join(select_ct_query[x] for x in key_select_list)
         return super()._get_sql() + "union (select {} {} {})".format(
             select_ct,
-            self._from_statement("6_ct_commit"),
+            self._from_statement("60_ct_commit"),
             self._where_contract(),
         )

--- a/budget_control_expense/models/budget_period.py
+++ b/budget_control_expense/models/budget_period.py
@@ -17,7 +17,7 @@ class BudgetPeriod(models.Model):
 
     def _budget_info_query(self):
         query = super()._budget_info_query()
-        query["info_cols"]["amount_expense"] = ("5_ex_commit", True)
+        query["info_cols"]["amount_expense"] = ("50_ex_commit", True)
         return query
 
     @api.depends("control_budget")

--- a/budget_control_expense/report/budget_monitor_report.py
+++ b/budget_control_expense/report/budget_monitor_report.py
@@ -10,7 +10,7 @@ class BudgetMonitorReport(models.Model):
         return super()._get_consumed_sources() + [
             {
                 "model": ("hr.expense", "Expense"),
-                "type": ("5_ex_commit", "EX Commit"),
+                "type": ("50_ex_commit", "EX Commit"),
                 "budget_move": ("expense_budget_move", "expense_id"),
                 "source_doc": ("hr_expense_sheet", "sheet_id"),
             }
@@ -20,11 +20,11 @@ class BudgetMonitorReport(models.Model):
         return ""
 
     def _get_sql(self):
-        select_ex_query = self._select_statement("5_ex_commit")
+        select_ex_query = self._select_statement("50_ex_commit")
         key_select_list = sorted(select_ex_query.keys())
         select_ex = ", ".join(select_ex_query[x] for x in key_select_list)
         return super()._get_sql() + "union (select {} {} {})".format(
             select_ex,
-            self._from_statement("5_ex_commit"),
+            self._from_statement("50_ex_commit"),
             self._where_expense(),
         )

--- a/budget_control_purchase/models/budget_period.py
+++ b/budget_control_purchase/models/budget_period.py
@@ -17,7 +17,7 @@ class BudgetPeriod(models.Model):
 
     def _budget_info_query(self):
         query = super()._budget_info_query()
-        query["info_cols"]["amount_purchase"] = ("3_po_commit", True)
+        query["info_cols"]["amount_purchase"] = ("30_po_commit", True)
         return query
 
     @api.depends("control_budget")

--- a/budget_control_purchase/report/budget_monitor_report.py
+++ b/budget_control_purchase/report/budget_monitor_report.py
@@ -10,7 +10,7 @@ class BudgetMonitorReport(models.Model):
         return super()._get_consumed_sources() + [
             {
                 "model": ("purchase.order.line", "Purchase Line"),
-                "type": ("3_po_commit", "PO Commit"),
+                "type": ("30_po_commit", "PO Commit"),
                 "budget_move": ("purchase_budget_move", "purchase_line_id"),
                 "source_doc": ("purchase_order", "purchase_id"),
             }
@@ -20,11 +20,11 @@ class BudgetMonitorReport(models.Model):
         return ""
 
     def _get_sql(self):
-        select_po_query = self._select_statement("3_po_commit")
+        select_po_query = self._select_statement("30_po_commit")
         key_select_list = sorted(select_po_query.keys())
         select_po = ", ".join(select_po_query[x] for x in key_select_list)
         return super()._get_sql() + "union (select {} {} {})".format(
             select_po,
-            self._from_statement("3_po_commit"),
+            self._from_statement("30_po_commit"),
             self._where_purchase(),
         )

--- a/budget_control_purchase_request/models/budget_period.py
+++ b/budget_control_purchase_request/models/budget_period.py
@@ -17,7 +17,7 @@ class BudgetPeriod(models.Model):
 
     def _budget_info_query(self):
         query = super()._budget_info_query()
-        query["info_cols"]["amount_purchase_request"] = ("2_pr_commit", True)
+        query["info_cols"]["amount_purchase_request"] = ("20_pr_commit", True)
         return query
 
     @api.depends("control_budget")

--- a/budget_control_purchase_request/report/budget_monitor_report.py
+++ b/budget_control_purchase_request/report/budget_monitor_report.py
@@ -10,7 +10,7 @@ class BudgetMonitorReport(models.Model):
         return super()._get_consumed_sources() + [
             {
                 "model": ("purchase.request.line", "Purchase Request Line"),
-                "type": ("2_pr_commit", "PR Commit"),
+                "type": ("20_pr_commit", "PR Commit"),
                 "budget_move": (
                     "purchase_request_budget_move",
                     "purchase_request_line_id",
@@ -23,11 +23,11 @@ class BudgetMonitorReport(models.Model):
         return ""
 
     def _get_sql(self):
-        select_pr_query = self._select_statement("2_pr_commit")
+        select_pr_query = self._select_statement("20_pr_commit")
         key_select_list = sorted(select_pr_query.keys())
         select_pr = ", ".join(select_pr_query[x] for x in key_select_list)
         return super()._get_sql() + "union (select {} {} {})".format(
             select_pr,
-            self._from_statement("2_pr_commit"),
+            self._from_statement("20_pr_commit"),
             self._where_purchase_request(),
         )

--- a/budget_control_revision/models/budget_control.py
+++ b/budget_control_revision/models/budget_control.py
@@ -32,7 +32,7 @@ class BudgetControl(models.Model):
 
     def _filter_by_budget_control(self, val):
         res = super()._filter_by_budget_control(val)
-        if val["amount_type"] != "1_budget":
+        if val["amount_type"] != "10_budget":
             return res
         revision_number = (
             0 if not val["revision_number"] else int(val["revision_number"])

--- a/l10n_th_gov_purchase_agreement_budget_control/models/budget_period.py
+++ b/l10n_th_gov_purchase_agreement_budget_control/models/budget_period.py
@@ -9,5 +9,5 @@ class BudgetPeriod(models.Model):
 
     def _budget_info_query(self):
         query = super()._budget_info_query()
-        query["info_cols"]["amount_agreement"] = ("7_agreement_commit", True)
+        query["info_cols"]["amount_agreement"] = ("70_agreement_commit", True)
         return query

--- a/l10n_th_gov_purchase_agreement_budget_control/report/budget_monitor_report.py
+++ b/l10n_th_gov_purchase_agreement_budget_control/report/budget_monitor_report.py
@@ -11,7 +11,7 @@ class BudgetMonitorReport(models.Model):
         return super()._get_consumed_sources() + [
             {
                 "model": ("purchase.order.line", "Purchase Line"),
-                "type": ("7_agreement_commit", "Agreement Commit"),
+                "type": ("70_agreement_commit", "Agreement Commit"),
                 "budget_move": ("purchase_budget_move", "purchase_line_id"),
                 "source_doc": ("purchase_order", "purchase_id"),
             }
@@ -25,7 +25,7 @@ class BudgetMonitorReport(models.Model):
         return where_purchase
 
     def _get_sql(self):
-        type_commit = "7_agreement_commit"
+        type_commit = "70_agreement_commit"
         select_po_query = self._select_statement(type_commit)
         key_select_list = sorted(select_po_query.keys())
         select_po = ", ".join(select_po_query[x] for x in key_select_list)


### PR DESCRIPTION
This PR is fixed prefix sequence budget (amount type)

**Before**
1_budget
2_pr_commit
3_po_commit
4_av_commit
5_ex_commit
6_ct_commit
7_agreement_commit
8_actual

If we have extension module to commit budget and need add it after ex, it can't do that because sequence use 1 digit.
We will change sequence to 2 digits for other module can add other commit in the gap

**After**
10_budget
20_pr_commit
30_po_commit
40_av_commit
50_ex_commit
60_ct_commit
70_agreement_commit
80_actual