### PR TITLE
[18.0][IMP] budget_control_revision with lock amount

### DIFF
--- a/budget_control_revision/models/budget_control.py
+++ b/budget_control_revision/models/budget_control.py
@@ -1,6 +1,8 @@
 # Copyright 2021 Ecosoft Co., Ltd. (http://ecosoft.co.th)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
+from dateutil.relativedelta import relativedelta
+
 from odoo import api, fields, models
 from odoo.exceptions import UserError
 
@@ -19,6 +21,10 @@ class BudgetControl(models.Model):
     init_revision = fields.Boolean(
         compute="_compute_init_revision",
         store=True,
+    )
+    date_range_readonly = fields.Many2one(
+        comodel_name="date.range",
+        compute="_compute_date_range_readonly",
     )
 
     # Add budget_period_id and analytic account for check constrains
@@ -40,6 +46,18 @@ class BudgetControl(models.Model):
         for rec in self:
             rec.init_revision = not rec.revision_number
 
+    def _compute_date_range_readonly(self):
+        for rec in self:
+            line_readonly = rec.line_ids.filtered(lambda line: line.is_readonly)
+            rec.date_range_readonly = (
+                max(
+                    line_readonly.mapped("date_range_id"),
+                    key=lambda line: line.date_end,
+                )
+                if line_readonly
+                else False
+            )
+
     def _filter_by_budget_control(self, val):
         res = super()._filter_by_budget_control(val)
         if val["amount_type"] != "10_budget":
@@ -58,3 +76,40 @@ class BudgetControl(models.Model):
                 )
             )
         return self.create_revision()
+
+    def create_revision(self):
+        """Not checked amount when revision"""
+        return super(BudgetControl, self.with_context(edit_amount=1)).create_revision()
+
+
+class BudgetControlLine(models.Model):
+    _inherit = "budget.control.line"
+
+    is_readonly = fields.Boolean(
+        compute="_compute_amount_readonly",
+    )
+
+    @api.depends("budget_control_id")
+    def _compute_amount_readonly(self):
+        lock_amount = self.env.company.budget_control_revision_lock_amount
+        date = fields.Date.context_today(self)
+        # Change current month to previous month
+        if lock_amount == "last":
+            date = date.replace(day=1) - relativedelta(days=1)
+
+        for rec in self:
+            rec.is_readonly = not (
+                rec.budget_control_id.init_revision
+                or lock_amount == "none"
+                or rec.date_from > date
+            )
+
+    @api.constrains("amount")
+    def _check_amount_readonly(self):
+        """Skip check amount with context edit_amount (if any)"""
+        edit_amount = self.env.context.get("edit_amount", False)
+        if edit_amount:
+            return
+
+        if any(rec.is_readonly for rec in self):
+            raise UserError(self.env._("You can not edit past amount."))

--- a/budget_control_revision/models/res_company.py
+++ b/budget_control_revision/models/res_company.py
@@ -15,3 +15,14 @@ class ResCompany(models.Model):
         default="manual",
         help="all budget control will auto/manual cancel before budget plan is revised",
     )
+    budget_control_revision_lock_amount = fields.Selection(
+        selection=[
+            ("none", "No Lock"),
+            ("current", "Lock until current month"),
+            ("last", "Lock until previous month"),
+        ],
+        string="Budget Control Revision - Lock Amount",
+        default="none",
+        help="Determines the lock amount period for budget control revisions. \
+            Options are: No Lock, Lock until current month, Lock until previous month",
+    )

--- a/budget_control_revision/models/res_config_settings.py
+++ b/budget_control_revision/models/res_config_settings.py
@@ -10,3 +10,7 @@ class ResConfigSettings(models.TransientModel):
     budget_plan_revision_cancel = fields.Selection(
         related="company_id.budget_plan_revision_cancel", readonly=False
     )
+    budget_control_revision_lock_amount = fields.Selection(
+        related="company_id.budget_control_revision_lock_amount",
+        readonly=False,
+    )

--- a/budget_control_revision/tests/test_budget_control_revision.py
+++ b/budget_control_revision/tests/test_budget_control_revision.py
@@ -5,7 +5,7 @@ import ast
 
 from freezegun import freeze_time
 
-from odoo import Command
+from odoo import Command, fields
 from odoo.exceptions import UserError
 from odoo.tests import tagged
 
@@ -15,7 +15,7 @@ from odoo.addons.budget_control.tests.common import get_budget_common_class
 @tagged("post_install", "-at_install")
 class TestBudgetControlRevision(get_budget_common_class()):
     @classmethod
-    @freeze_time("2001-02-01")
+    @freeze_time("2001-04-01 15:00:00")
     def setUpClass(cls):
         super().setUpClass()
 
@@ -131,3 +131,89 @@ class TestBudgetControlRevision(get_budget_common_class()):
         self.assertFalse(bc_new_revision.init_revision)
         self.assertEqual(bc_new_revision.state, "draft")
         self.assertAlmostEqual(bc_new_revision.amount_budget, 0.0)
+
+    @freeze_time("2001-04-01 15:00:00")
+    def test_04_budget_control_revision_lock_amount_current(self):
+        """Revision budget control, commitment should normal process"""
+        self.assertEqual(self.env.company.budget_plan_revision_cancel, "manual")
+        self.assertEqual(self.env.company.budget_control_revision_lock_amount, "none")
+        self.env.company.budget_plan_revision_cancel = "auto"
+        self.env.company.budget_control_revision_lock_amount = "current"
+
+        self.assertEqual(self.budget_plan.state, "confirm")
+        self.budget_plan.action_create_update_budget_control()
+        self.budget_plan.action_done()
+        self.assertEqual(self.budget_plan.revision_number, 0)
+        self.assertTrue(self.budget_plan.init_revision)
+
+        # Refresh data
+        self.budget_plan.invalidate_recordset()
+        self.budget_control = self.budget_plan.budget_control_ids
+        self.assertEqual(self.budget_control.revision_number, 0)
+        self.assertTrue(self.budget_control.init_revision)
+        self.assertEqual(self.budget_control.state, "draft")
+        self.assertTrue(self.budget_control.active)
+
+        self.budget_control.template_line_ids = [
+            self.template_line1.id,
+            self.template_line2.id,
+            self.template_line3.id,
+        ]
+
+        # Test item created for 3 kpi x 4 quarters = 12 budget items
+        self.budget_control.prepare_budget_control_matrix()
+
+        # Initial Revision, It should editable
+        today = fields.Date.today()
+
+        # 2001-01-01 to 2001-03-31
+        line1_quarter1 = self.budget_control.line_ids[0]
+
+        self.assertLess(line1_quarter1.date_from, today)
+        self.assertLess(line1_quarter1.date_to, today)
+        self.assertFalse(line1_quarter1.is_readonly)
+        line1_quarter1.amount = 1.0
+
+        # Revision budget plan
+        self.budget_plan.action_cancel()
+        self.assertEqual(self.budget_plan.state, "cancel")
+        action_plan_revision = self.budget_plan.create_revision()
+
+        domain_list = ast.literal_eval(action_plan_revision["domain"])
+        plan_new_revision = self.BudgetPlan.browse(domain_list[0][2])
+
+        # Update budget control, it should auto cancel
+        plan_new_revision.action_confirm()
+        plan_new_revision.action_create_update_budget_control()
+
+        # Refresh data
+        plan_new_revision.invalidate_recordset()
+        self.budget_control_revision = plan_new_revision.budget_control_ids
+        self.assertEqual(self.budget_control_revision.revision_number, 1)
+        self.assertFalse(self.budget_control_revision.init_revision)
+        self.assertEqual(self.budget_control_revision.state, "draft")
+        self.assertTrue(self.budget_control_revision.active)
+
+        self.budget_control_revision.template_line_ids = [
+            self.template_line1.id,
+            self.template_line2.id,
+            self.template_line3.id,
+        ]
+
+        # Test item created for 3 kpi x 4 quarters = 12 budget items
+        self.budget_control_revision.prepare_budget_control_matrix()
+        # 2001-01-01 to 2001-03-31
+        line1_quarter1 = self.budget_control_revision.line_ids[0]
+
+        self.assertLess(line1_quarter1.date_from, today)
+        self.assertLess(line1_quarter1.date_to, today)
+        self.assertTrue(line1_quarter1.is_readonly)
+        with self.assertRaisesRegex(UserError, "You can not edit past amount."):
+            line1_quarter1.amount = 1.0
+
+        # Config lock amount with previous month
+        self.env.company.budget_control_revision_lock_amount = "last"
+        line1_quarter1._compute_amount_readonly()
+        self.assertTrue(line1_quarter1.is_readonly)
+        with self.assertRaisesRegex(UserError, "You can not edit past amount."):
+            line1_quarter1.amount = 1.0

--- a/budget_control_revision/views/budget_control_view.xml
+++ b/budget_control_revision/views/budget_control_view.xml
@@ -1,5 +1,21 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <odoo>
+    <!-- Budget Control Lines -->
+    <record id="budget_control_line_list_view_readonly" model="ir.ui.view">
+        <field name="name">budget.control.line.tree.view.readonly</field>
+        <field name="model">budget.control.line</field>
+        <field
+            name="inherit_id"
+            ref="budget_control.budget_control_line_list_view_readonly"
+        />
+        <field name="arch" type="xml">
+            <xpath expr="//list" position="inside">
+                <field name="is_readonly" />
+            </xpath>
+        </field>
+    </record>
+
+    <!-- Budget Control -->
     <record id="budget_control_view_form_without_header" model="ir.ui.view">
         <field name="name">budget.control.view.form.without.header</field>
         <field name="model">budget.control</field>
@@ -85,6 +101,23 @@
                         </list>
                     </field>
                 </page>
+            </xpath>
+            <!-- Add info -->
+            <xpath expr="//page[@name='items']/div[@name='buttons']" position="before">
+                <div
+                    class="alert alert-info info_icon mt-2 d-flex align-items-center"
+                    role="alert"
+                    invisible="not date_range_readonly or state != 'draft'"
+                >
+                    <span class="fa fa-info fa-2x me-2" />
+                    <span>
+                        Budget control lines with a date range later than
+                        <b>
+                        <field name="date_range_readonly" options="{'no_open': True}" />
+                    </b>
+                        are editable.
+                    </span>
+                </div>
             </xpath>
         </field>
     </record>

--- a/budget_control_revision/views/res_config_settings_views.xml
+++ b/budget_control_revision/views/res_config_settings_views.xml
@@ -19,6 +19,22 @@
                     <field name="budget_plan_revision_cancel" widget="radio" />
                 </setting>
             </xpath>
+            <xpath
+                expr="//block[@name='budget_control_options_container']"
+                position="inside"
+            >
+                <setting
+                    id="budget_control_revision_lock_amount"
+                    string="Revision Lock Amount"
+                    help="Users can change this setting to prevent editing after a revision has been made."
+                >
+                    <field
+                        name="budget_control_revision_lock_amount"
+                        class="o_light_label"
+                        widget="radio"
+                    />
+                </setting>
+            </xpath>
         </field>
     </record>
 </odoo>


### PR DESCRIPTION
Combine module `budget_control_revision_lock_amount` to `budget_control_revision`

TODO:
~~- [ ] Show red color or readonly when line is readonly~~

Add info instead red color
![Selection_011](https://github.com/user-attachments/assets/4da8c0bc-3ae5-44cb-aeba-66436324b388)
