### PR TITLE
[FIX] budget_control_*: change position sequence

### DIFF
--- a/budget_control_advance_clearing/views/budget_control_view.xml
+++ b/budget_control_advance_clearing/views/budget_control_view.xml
@@ -3,9 +3,12 @@
     <record id="budget_control_view_list" model="ir.ui.view">
         <field name="name">budget.control.view.list</field>
         <field name="model">budget.control</field>
-        <field name="inherit_id" ref="budget_control.budget_control_view_list" />
+        <field
+            name="inherit_id"
+            ref="budget_control_expense.budget_control_view_list"
+        />
         <field name="arch" type="xml">
-            <xpath expr="//list/field[@name='amount_expense']" position="before">
+            <xpath expr="//field[@name='amount_expense']" position="before">
                 <field name="amount_advance" optional="hide" />
             </xpath>
         </field>
@@ -13,12 +16,12 @@
     <record id="budget_control_view_form" model="ir.ui.view">
         <field name="name">budget.control.view.form</field>
         <field name="model">budget.control</field>
-        <field name="inherit_id" ref="budget_control.budget_control_view_form" />
+        <field
+            name="inherit_id"
+            ref="budget_control_expense.budget_control_view_form"
+        />
         <field name="arch" type="xml">
-            <xpath
-                expr="//group[@name='amount_budget']/field[@name='amount_expense']"
-                position="before"
-            >
+            <xpath expr="//field[@name='amount_expense']" position="before">
                 <field name="amount_advance" />
             </xpath>
         </field>

--- a/budget_control_expense/views/budget_control_view.xml
+++ b/budget_control_expense/views/budget_control_view.xml
@@ -5,7 +5,7 @@
         <field name="model">budget.control</field>
         <field name="inherit_id" ref="budget_control.budget_control_view_list" />
         <field name="arch" type="xml">
-            <xpath expr="//list/field[@name='amount_budget']" position="after">
+            <xpath expr="//list/field[@name='amount_commit']" position="before">
                 <field name="amount_expense" optional="hide" />
             </xpath>
         </field>
@@ -15,10 +15,7 @@
         <field name="model">budget.control</field>
         <field name="inherit_id" ref="budget_control.budget_control_view_form" />
         <field name="arch" type="xml">
-            <xpath
-                expr="//group[@name='amount_budget']/field[@name='amount_budget']"
-                position="after"
-            >
+            <xpath expr="//field[@name='amount_commit']" position="before">
                 <field name="amount_expense" />
             </xpath>
         </field>

--- a/budget_control_purchase/views/budget_control_view.xml
+++ b/budget_control_purchase/views/budget_control_view.xml
@@ -5,7 +5,7 @@
         <field name="model">budget.control</field>
         <field name="inherit_id" ref="budget_control.budget_control_view_list" />
         <field name="arch" type="xml">
-            <xpath expr="//list/field[@name='amount_budget']" position="after">
+            <xpath expr="//list/field[@name='amount_commit']" position="before">
                 <field name="amount_purchase" optional="hide" />
             </xpath>
         </field>
@@ -15,10 +15,7 @@
         <field name="model">budget.control</field>
         <field name="inherit_id" ref="budget_control.budget_control_view_form" />
         <field name="arch" type="xml">
-            <xpath
-                expr="//group[@name='amount_budget']/field[@name='amount_budget']"
-                position="after"
-            >
+            <xpath expr="//field[@name='amount_commit']" position="before">
                 <field name="amount_purchase" />
             </xpath>
         </field>

--- a/budget_control_purchase/views/budget_period_view.xml
+++ b/budget_control_purchase/views/budget_period_view.xml
@@ -5,6 +5,7 @@
         <field name="model">budget.period</field>
         <field name="inherit_id" ref="budget_control.budget_period_view_form" />
         <field name="arch" type="xml">
+            <!-- Add purchase before account -->
             <xpath expr="//label[@for='account']" position="before">
                 <label for="purchase" class="d-none" invisible="not control_budget" />
                 <div invisible="not control_budget">

--- a/budget_control_purchase_request/views/budget_control_view.xml
+++ b/budget_control_purchase_request/views/budget_control_view.xml
@@ -3,9 +3,12 @@
     <record id="budget_control_view_list" model="ir.ui.view">
         <field name="name">budget.control.view.list</field>
         <field name="model">budget.control</field>
-        <field name="inherit_id" ref="budget_control.budget_control_view_list" />
+        <field
+            name="inherit_id"
+            ref="budget_control_purchase.budget_control_view_list"
+        />
         <field name="arch" type="xml">
-            <xpath expr="//list/field[@name='amount_budget']" position="after">
+            <xpath expr="//field[@name='amount_purchase']" position="before">
                 <field name="amount_purchase_request" optional="hide" />
             </xpath>
         </field>
@@ -13,12 +16,12 @@
     <record id="budget_control_view_form" model="ir.ui.view">
         <field name="name">budget.control.view.form</field>
         <field name="model">budget.control</field>
-        <field name="inherit_id" ref="budget_control.budget_control_view_form" />
+        <field
+            name="inherit_id"
+            ref="budget_control_purchase.budget_control_view_form"
+        />
         <field name="arch" type="xml">
-            <xpath
-                expr="//group[@name='amount_budget']/field[@name='amount_budget']"
-                position="after"
-            >
+            <xpath expr="//field[@name='amount_purchase']" position="before">
                 <field name="amount_purchase_request" />
             </xpath>
         </field>


### PR DESCRIPTION
Sequence of amount is
- Budget (First)
- Actual (Last)

When install `budget_control_expense`, `Expense` will add position before `Actual`
When install `budget_control_advance_clearing`, `Advance` will add position before `Expense`
When install `budget_control_purchase`, `Purchase` will add position before `Actual`
When install `budget_control_purchase_request`, `Purchase Request` will add position before `Expense`