### PR TITLE
[18.0][REMOVE] budget_control_*: remove _budget_analytic_field and _analytic_tag_field_name

### DIFF
--- a/account_payment_multi_deduction_budget_plan_detail/tests/test_payment_multi_deduction_budget.py
+++ b/account_payment_multi_deduction_budget_plan_detail/tests/test_payment_multi_deduction_budget.py
@@ -17,8 +17,12 @@ class TestPaymentMultiDeductionBudget(TestBudgetPlanDetail):
         # Create same analytic, difference fund, difference analytic tags
         # line 1: Costcenter1, Fund1, Tag1, 600.0
         # line 2: Costcenter1, Fund1, Tag2, 600.0
-        # line 3: Costcenter1, Fund2,     , 600.0
-        # line 4: CostcenterX, Fund1,     , 600.0
+        # line 3: Costcenter1, Fund2, Tag1, 600.0
+        # line 4: Costcenter1, Fund2,     , 600.0
+        # line 5: CostcenterX, Fund1, Tag1, 600.0
+        # line 6: CostcenterX, Fund2, Tag1, 600.0
+        # line 7: CostcenterX, Fund2, Tag2, 600.0
+        # line 8: CostcenterX, Fund1,     , 600.0
         cls._create_budget_plan_line_detail(cls, cls.budget_plan)
         cls.budget_plan.action_confirm_plan_detail()
         cls.budget_plan.action_confirm()
@@ -27,7 +31,7 @@ class TestPaymentMultiDeductionBudget(TestBudgetPlanDetail):
 
         # Refresh data and Prepare budget control
         cls.budget_plan.invalidate_recordset()
-        # Get 1 budget control, Costcenter1 has 3 plan detail (600, 600, 600)
+        # Get 1 budget control, Costcenter1 has 4 plan detail
         budget_control = cls.budget_plan.budget_control_ids[0]
         budget_control.template_line_ids = [
             cls.template_line1.id,
@@ -39,11 +43,11 @@ class TestPaymentMultiDeductionBudget(TestBudgetPlanDetail):
         budget_control.prepare_budget_control_matrix()
         assert len(budget_control.line_ids) == 12
         # Costcenter1 has 3 plan detail
-        # Assign budget.control amount: KPI1 = 1500, 200, 100
+        # Assign budget.control amount: KPI1 = 1500, 500, 400
         bc_items = budget_control.line_ids.filtered(lambda x: x.kpi_id == cls.kpi1)
         bc_items[0].write({"amount": 1500})
-        bc_items[1].write({"amount": 200})
-        bc_items[2].write({"amount": 100})
+        bc_items[1].write({"amount": 500})
+        bc_items[2].write({"amount": 400})
 
         # Control budget
         budget_control.action_submit()

--- a/budget_control/models/base_budget_move.py
+++ b/budget_control/models/base_budget_move.py
@@ -125,6 +125,20 @@ class BudgetDoclineMixinBase(models.AbstractModel):
         "rejected",
     ]  # Never set date commit states
 
+    def _convert_analytics(self, analytic_distribution=False):
+        Analytic = self.env["account.analytic.account"]
+        analytics = analytic_distribution or self[self._budget_analytic_field]
+        if not analytics:
+            return Analytic
+        # Check analytic from distribution it send data with JSON type 'dict'
+        # and we need convert it to analytic object
+        if self._budget_analytic_field == "analytic_distribution":
+            account_analytic_ids = [
+                int(v) for k in analytics.keys() for v in k.split(",")
+            ]
+            analytics = Analytic.browse(account_analytic_ids)
+        return analytics
+
 
 class BudgetDoclineMixin(models.AbstractModel):
     _name = "budget.docline.mixin"
@@ -174,20 +188,6 @@ class BudgetDoclineMixin(models.AbstractModel):
 
     def _valid_commit_state(self):
         raise ValidationError(self.env._("No implementation error!"))
-
-    def _convert_analytics(self, analytic_distribution=False):
-        Analytic = self.env["account.analytic.account"]
-        analytics = analytic_distribution or self[self._budget_analytic_field]
-        if not analytics:
-            return Analytic
-        # Check analytic from distribution it send data with JSON type 'dict'
-        # and we need convert it to analytic object
-        if self._budget_analytic_field == "analytic_distribution":
-            account_analytic_ids = [
-                int(v) for k in analytics.keys() for v in k.split(",")
-            ]
-            analytics = Analytic.browse(account_analytic_ids)
-        return analytics
 
     @api.depends(lambda self: [self._budget_analytic_field])
     def _compute_auto_adjust_date_commit(self):

--- a/budget_control/models/budget_move_adjustment.py
+++ b/budget_control/models/budget_move_adjustment.py
@@ -117,7 +117,6 @@ class BudgetMoveAdjustmentItem(models.Model):
     _check_company_auto = True
     _budget_date_commit_fields = ["adjust_id.date_commit"]
     _budget_move_model = "account.budget.move"
-    _budget_analytic_field = "analytic_distribution"
     _doc_rel = "adjust_id"
 
     adjust_id = fields.Many2one(

--- a/budget_control/models/budget_period.py
+++ b/budget_control/models/budget_period.py
@@ -136,31 +136,30 @@ class BudgetPeriod(models.Model):
         self = self.sudo()
         budget_constraints = self._get_budget_constraint()
         all_analytics = doclines.mapped(doclines._budget_analytic_field)
+
         # Get All Analytic Account
-        if doclines._budget_analytic_field == "analytic_distribution":
-            all_analytic_ids = set()
-            for data_dict in all_analytics:
-                # Check percent analytic account must be 100% only
-                total_sum = sum(data_dict.values())
-                if (
-                    float_compare(
-                        total_sum,
-                        100.0,
-                        precision_rounding=2,
-                    )
-                    != 0
-                ):
-                    raise UserError(
-                        self.env._(
-                            "The total sum percent of Analytic Account must 100%. "
-                            "Please check again."
-                        )
-                    )
-                all_analytic_ids.update(
-                    int(aa) for key in data_dict.keys() for aa in key.split(",")
+        all_analytic_ids = set()
+        for data_dict in all_analytics:
+            # Check percent analytic account must be 100% only
+            total_sum = sum(data_dict.values())
+            if (
+                float_compare(
+                    total_sum,
+                    100.0,
+                    precision_rounding=2,
                 )
-        else:
-            all_analytic_ids = all_analytics
+                != 0
+            ):
+                raise UserError(
+                    self.env._(
+                        "The total sum percent of Analytic Account must 100%. "
+                        "Please check again."
+                    )
+                )
+            all_analytic_ids.update(
+                int(aa) for key in data_dict.keys() for aa in key.split(",")
+            )
+
         # Check budget by group analytic. For case many budget periods in one document.
         for aa in all_analytic_ids:
             if isinstance(aa, int):

--- a/budget_control/tests/common.py
+++ b/budget_control/tests/common.py
@@ -32,6 +32,7 @@ class BudgetControlCommon(TransactionCase):
         cls.Account = cls.env["account.account"]
         cls.BudgetPlan = cls.env["budget.plan"]
         cls.BudgetControl = cls.env["budget.control"]
+        cls.BudgetTransfer = cls.env["budget.transfer"]
         cls.BudgetTemplate = cls.env["budget.template"]
         cls.BudgetKPI = cls.env["budget.kpi"]
         cls.Product = cls.env["product.product"]
@@ -188,3 +189,14 @@ class BudgetControlCommon(TransactionCase):
             }
         )
         return invoice
+
+    def _create_budget_transfer(self, budget_from, budget_to, amount):
+        line_vals = {
+            "budget_control_from_id": budget_from.id,
+            "budget_control_to_id": budget_to.id,
+            "amount": amount,
+        }
+        budget_transfer = self.BudgetTransfer.create(
+            {"transfer_item_ids": [Command.create(line_vals)]}
+        )
+        return budget_transfer

--- a/budget_control/tests/test_budget_control.py
+++ b/budget_control/tests/test_budget_control.py
@@ -19,11 +19,14 @@ class TestBudgetControl(get_budget_common_class()):
     def setUpClass(cls):
         super().setUpClass()
 
-        # Create budget plan with 1 analytic
+        # Create budget plan with 2 analytic
         lines = [
             Command.create(
                 {"analytic_account_id": cls.costcenter1.id, "amount": 2400.0}
-            )
+            ),
+            Command.create(
+                {"analytic_account_id": cls.costcenterX.id, "amount": 2400.0}
+            ),
         ]
         cls.budget_plan = cls.create_budget_plan(
             cls,
@@ -38,7 +41,8 @@ class TestBudgetControl(get_budget_common_class()):
         # Refresh data
         cls.budget_plan.invalidate_recordset()
 
-        cls.budget_control = cls.budget_plan.budget_control_ids
+        # Budget Control 1
+        cls.budget_control = cls.budget_plan.budget_control_ids[0]
         cls.budget_control.template_line_ids = [
             cls.template_line1.id,
             cls.template_line2.id,
@@ -56,6 +60,28 @@ class TestBudgetControl(get_budget_common_class()):
             {"amount": 200}
         )
         cls.budget_control.line_ids.filtered(lambda x: x.kpi_id == cls.kpi3).write(
+            {"amount": 300}
+        )
+
+        # Budget Control 2
+        cls.budget_control2 = cls.budget_plan.budget_control_ids[1]
+        cls.budget_control2.template_line_ids = [
+            cls.template_line1.id,
+            cls.template_line2.id,
+            cls.template_line3.id,
+        ]
+
+        # Test item created for 3 kpi x 4 quarters = 12 budget items
+        cls.budget_control2.prepare_budget_control_matrix()
+        assert len(cls.budget_control2.line_ids) == 12
+        # Assign budget.control amount: KPI1 = 100x4=400, KPI2=800, KPI3=1,200
+        cls.budget_control2.line_ids.filtered(lambda x: x.kpi_id == cls.kpi1).write(
+            {"amount": 100}
+        )
+        cls.budget_control2.line_ids.filtered(lambda x: x.kpi_id == cls.kpi2).write(
+            {"amount": 200}
+        )
+        cls.budget_control2.line_ids.filtered(lambda x: x.kpi_id == cls.kpi3).write(
             {"amount": 300}
         )
 
@@ -84,8 +110,8 @@ class TestBudgetControl(get_budget_common_class()):
 
     @freeze_time("2001-02-01")
     def test_01_budget_plan_create_line_from_wizard(self):
-        self.assertEqual(len(self.budget_plan.line_ids), 1)
-        self.assertAlmostEqual(self.budget_plan.total_amount, 2400)
+        self.assertEqual(len(self.budget_plan.line_ids), 2)
+        self.assertAlmostEqual(self.budget_plan.total_amount, 4800)  # 2 budget 2400*2
         self.assertEqual(self.budget_plan.state, "done")
 
         # Reset plan to draft for add new analytic
@@ -101,7 +127,7 @@ class TestBudgetControl(get_budget_common_class()):
         # Create with no active_id, it should nothing to do
         wizard = self.PlanAnalyticSelect.create({"analytic_account_ids": []})
         action = wizard.action_add()
-        self.assertEqual(len(self.budget_plan.line_ids), 1)
+        self.assertEqual(len(self.budget_plan.line_ids), 2)
 
         # Create with empty analytic, it should remove all plan lines
         wizard = self.PlanAnalyticSelect.with_context(
@@ -129,7 +155,7 @@ class TestBudgetControl(get_budget_common_class()):
 
     @freeze_time("2001-02-01")
     def test_03_budget_plan_check_control(self):
-        self.assertEqual(len(self.budget_plan.budget_control_ids), 1)
+        self.assertEqual(len(self.budget_plan.budget_control_ids), 2)
         action = self.budget_plan.button_open_budget_control()
         self.assertEqual(
             action["domain"][0][2], self.budget_plan.budget_control_ids.ids
@@ -420,7 +446,87 @@ class TestBudgetControl(get_budget_common_class()):
         )
 
     @freeze_time("2001-02-01")
-    def test_15_budget_adjustment(self):
+    def test_15_budget_control_analytic_exceed_percent(self):
+        """Check control analytic account exceed 100%"""
+        analytic_distribution = {self.costcenter1.id: 130}
+        bill1 = self._create_simple_bill(analytic_distribution, self.account_kpi1, 100)
+        with self.assertRaisesRegex(
+            UserError,
+            "The total sum percent of Analytic Account must 100%. Please check again.",
+        ):
+            bill1.action_post()
+
+    @freeze_time("2001-02-01")
+    def test_16_budget_transfer(self):
+        """Budget Transfer Process"""
+        # Transfer from budget_control to budget_control2
+        transfer = self._create_budget_transfer(
+            budget_from=self.budget_control, budget_to=self.budget_control2, amount=0.0
+        )
+        self.assertEqual(len(transfer.transfer_item_ids), 1)
+        self.assertAlmostEqual(self.budget_control.released_amount, 2400.0)
+        self.assertAlmostEqual(self.budget_control2.released_amount, 2400.0)
+        self.assertNotEqual(transfer.name, "/")
+        # Amount transfer available is not 0.0
+        self.assertNotEqual(transfer.transfer_item_ids.amount_from_available, 0.0)
+        self.assertNotEqual(transfer.transfer_item_ids.amount_to_available, 0.0)
+
+        # It should error
+        with self.assertRaisesRegex(UserError, "Transfer amount must be positive!"):
+            transfer.action_submit()
+
+        # Transfer with 2500.0 (exceed budget)
+        transfer.transfer_item_ids.write({"amount": 2500.0})
+        with self.assertRaisesRegex(UserError, "Transfer amount can not be exceeded"):
+            transfer.action_submit()
+
+        transfer.transfer_item_ids.write({"amount": 40.0})
+        transfer.action_submit()
+        self.assertEqual(transfer.state, "submit")
+
+        transfer.action_transfer()
+        self.assertEqual(transfer.state, "transfer")
+        self.assertEqual(len(self.budget_control.transfer_item_ids), 1)
+        self.assertAlmostEqual(self.budget_control.released_amount, 2360.0)
+        self.assertAlmostEqual(self.budget_control.transferred_amount, -40.0)
+        self.assertEqual(len(self.budget_control2.transfer_item_ids), 1)
+        self.assertAlmostEqual(self.budget_control2.released_amount, 2440.0)
+        self.assertAlmostEqual(self.budget_control2.transferred_amount, 40.0)
+
+        # Check snart button budget_control to transfer_items
+        action_transfer_from = self.budget_control.action_open_budget_transfer_item()
+        self.assertEqual(action_transfer_from["res_model"], "budget.transfer.item")
+        self.assertEqual(
+            action_transfer_from["domain"][0][2],
+            self.budget_control.transfer_item_ids.ids,
+        )
+
+        action_transfer_to = self.budget_control.action_open_budget_transfer_item()
+        self.assertEqual(action_transfer_to["res_model"], "budget.transfer.item")
+        self.assertEqual(
+            action_transfer_to["domain"][0][2],
+            self.budget_control2.transfer_item_ids.ids,
+        )
+
+        # Don't allow delete transfer document if not draft state
+        with self.assertRaisesRegex(
+            UserError, "You are trying to delete a record that is still referenced!"
+        ):
+            transfer.unlink()
+
+        transfer.action_reverse()
+        self.budget_control._compute_transferred_amount()
+        self.assertEqual(transfer.state, "reverse")
+        self.assertEqual(len(self.budget_control.transfer_item_ids), 1)
+        self.assertAlmostEqual(self.budget_control.released_amount, 2400.0)
+        self.assertAlmostEqual(self.budget_control.transferred_amount, 0.0)
+        self.budget_control2._compute_transferred_amount()
+        self.assertEqual(len(self.budget_control2.transfer_item_ids), 1)
+        self.assertAlmostEqual(self.budget_control2.released_amount, 2400.0)
+        self.assertAlmostEqual(self.budget_control2.transferred_amount, 0.0)
+
+    @freeze_time("2001-02-01")
+    def test_17_budget_adjustment(self):
         self.assertEqual(self.budget_control.amount_balance, 2400.0)
         budget_adjust = self.BudgetAdjust.create(
             {
@@ -439,7 +545,7 @@ class TestBudgetControl(get_budget_common_class()):
         budget_adjust.action_adjust()
         self.assertEqual(self.budget_control.amount_balance, 2300.0)
 
-    def test_16_budget_carry_forward(self):
+    def test_18_budget_carry_forward(self):
         """NOTE: This test is not yet implemented for budget_control"""
         budget_commit_forward = self.CommitForward.create(
             {

--- a/budget_control_operating_unit/tests/test_budget_control_operating_unit.py
+++ b/budget_control_operating_unit/tests/test_budget_control_operating_unit.py
@@ -17,9 +17,6 @@ class TestBudgetControlOperatingUnit(get_budget_common_class(), TestOperatingUni
     @freeze_time("2001-02-01")
     def setUpClass(cls):
         super().setUpClass()
-        cls.BudgetTransfer = cls.env["budget.transfer"]
-        cls.BudgetMoveAdjustment = cls.env["budget.move.adjustment"]
-
         cls.main_ou = cls.env.ref("operating_unit.main_operating_unit")
         cls.b2c_ou = cls.env.ref("operating_unit.b2c_operating_unit")
 
@@ -88,23 +85,6 @@ class TestBudgetControlOperatingUnit(get_budget_common_class(), TestOperatingUni
             {"amount": 300}
         )
 
-    def _create_budget_transfer(self, budget_from, budget_to, amount):
-        line_vals = {
-            "budget_control_from_id": budget_from.id,
-            "budget_control_to_id": budget_to.id,
-            "amount": amount,
-        }
-        if self.check_plan_detail_installed:
-            line_vals.update(
-                {
-                    "fund_from_id": self.fund1_g1.id,
-                    "fund_to_id": self.fund1_g1.id,
-                }
-            )
-        return self.BudgetTransfer.create(
-            {"transfer_item_ids": [Command.create(line_vals)]}
-        )
-
     @freeze_time("2001-02-01")
     def test_01_budget_control_operating_unit(self):
         """
@@ -150,12 +130,12 @@ class TestBudgetControlOperatingUnit(get_budget_common_class(), TestOperatingUni
     @freeze_time("2001-02-01")
     def test_02_budget_transfer_multi_ou(self):
         """Transfer with difference operating unit"""
-        self.costcenter1.operating_unit_ids = [(4, self.main_ou.id)]
+        self.costcenter1.operating_unit_ids = [Command.set(self.main_ou.ids)]
         self.assertEqual(
             self.budget_control.operating_unit_id, self.costcenter1.operating_unit_ids
         )
 
-        self.costcenterX.operating_unit_ids = [(4, self.b2c_ou.id)]
+        self.costcenterX.operating_unit_ids = [Command.set(self.b2c_ou.ids)]
         self.assertEqual(
             self.budget_control2.operating_unit_id, self.costcenterX.operating_unit_ids
         )
@@ -178,12 +158,12 @@ class TestBudgetControlOperatingUnit(get_budget_common_class(), TestOperatingUni
     @freeze_time("2001-02-01")
     def test_03_budget_transfer_same_ou(self):
         """Transfer with same operating unit"""
-        self.costcenter1.operating_unit_ids = [(4, self.main_ou.id)]
+        self.costcenter1.operating_unit_ids = [Command.set(self.main_ou.ids)]
         self.assertEqual(
             self.budget_control.operating_unit_id, self.costcenter1.operating_unit_ids
         )
 
-        self.costcenterX.operating_unit_ids = [(4, self.main_ou.id)]
+        self.costcenterX.operating_unit_ids = [Command.set(self.main_ou.ids)]
         self.assertEqual(
             self.budget_control2.operating_unit_id, self.costcenterX.operating_unit_ids
         )
@@ -214,13 +194,13 @@ class TestBudgetControlOperatingUnit(get_budget_common_class(), TestOperatingUni
         self.assertFalse(self.costcenter1.operating_unit_ids)
         self.assertFalse(self.budget_control.operating_unit_id)
 
-        self.costcenter1.operating_unit_ids = [(4, self.main_ou.id)]
+        self.costcenter1.operating_unit_ids = [Command.set(self.main_ou.ids)]
         self.assertEqual(
             self.budget_control.operating_unit_id, self.costcenter1.operating_unit_ids
         )
 
         # Create budget move adjustment
-        adjust_budget = self.BudgetMoveAdjustment.create({"date_commit": "2001-02-01"})
+        adjust_budget = self.BudgetAdjust.create({"date_commit": "2001-02-01"})
         self.assertEqual(adjust_budget.operating_unit_id, self.main_ou)
         # Create line with difference ou must be error
         with self.assertRaisesRegex(

--- a/budget_control_purchase/models/purchase.py
+++ b/budget_control_purchase/models/purchase.py
@@ -53,7 +53,6 @@ class PurchaseOrder(models.Model):
 class PurchaseOrderLine(models.Model):
     _name = "purchase.order.line"
     _inherit = ["purchase.order.line", "budget.docline.mixin"]
-    _budget_analytic_field = "analytic_distribution"
     _budget_date_commit_fields = ["order_id.write_date"]
     _budget_move_model = "purchase.budget.move"
     _doc_rel = "order_id"

--- a/budget_plan_detail/models/budget_move_adjustment.py
+++ b/budget_plan_detail/models/budget_move_adjustment.py
@@ -7,7 +7,6 @@ from odoo import fields, models
 class BudgetMoveAdjustmentItem(models.Model):
     _name = "budget.move.adjustment.item"
     _inherit = ["analytic.dimension.line", "budget.move.adjustment.item"]
-    _analytic_tag_field_name = "analytic_tag_ids"
 
     analytic_tag_ids = fields.Many2many(
         comodel_name="account.analytic.tag",

--- a/budget_plan_detail/tests/common.py
+++ b/budget_plan_detail/tests/common.py
@@ -116,16 +116,61 @@ class BudgetPlanDetailCommon(BudgetControlCommon):
         invoice = self.Move.create(invoice_list)
         return invoice
 
+    def _create_budget_transfer(
+        self,
+        budget_from,
+        budget_to,
+        amount,
+        fund_from=False,
+        fund_to=False,
+        analytic_tag_from=False,
+        analytic_tag_to=False,
+    ):
+        line_vals = {
+            "budget_control_from_id": budget_from.id,
+            "budget_control_to_id": budget_to.id,
+            "amount": amount,
+        }
+        if self.check_plan_detail_installed:
+            # Default is Fund1, Tag1
+            if analytic_tag_from != [] and not analytic_tag_from:
+                analytic_tag_from = budget_from.analytic_tag_ids[0]
+            if analytic_tag_to != [] and not analytic_tag_to:
+                analytic_tag_to = budget_to.analytic_tag_ids[0]
+            fund_from = fund_from or budget_from.fund_ids[0]
+            fund_to = fund_to or budget_to.fund_ids[0]
+            line_vals.update(
+                {
+                    "fund_from_id": fund_from.id,
+                    "analytic_tag_from_ids": analytic_tag_from
+                    and [Command.set(analytic_tag_from.ids)]
+                    or [],
+                    "fund_to_id": fund_to.id,
+                    "analytic_tag_to_ids": analytic_tag_to
+                    and [Command.set(analytic_tag_to.ids)]
+                    or [],
+                }
+            )
+        budget_transfer = self.BudgetTransfer.create(
+            {"transfer_item_ids": [Command.create(line_vals)]}
+        )
+        return budget_transfer
+
     def _create_budget_plan_line_detail(
-        self, budget_plan, lines_detail=False, amount=600.0
+        self, budget_plan, lines_detail=False, amount=600.0, auto_confirm=True
     ):
         if not lines_detail:
             # Create same analytic, difference fund, difference analytic tags
             # line 1: Costcenter1, Fund1, Tag1, 600.0
             # line 2: Costcenter1, Fund1, Tag2, 600.0
-            # line 3: Costcenter1, Fund2,     , 600.0
-            # line 4: CostcenterX, Fund1,     , 600.0
+            # line 3: Costcenter1, Fund2, Tag1, 600.0
+            # line 4: Costcenter1, Fund2,     , 600.0
+            # line 5: CostcenterX, Fund1, Tag1, 600.0
+            # line 6: CostcenterX, Fund2, Tag1, 600.0
+            # line 7: CostcenterX, Fund2, Tag2, 600.0
+            # line 8: CostcenterX, Fund1,     , 600.0
             lines_detail = [
+                # Line 1 - 4
                 {
                     "plan_id": budget_plan.id,
                     "analytic_account_id": self.costcenter1.id,
@@ -144,6 +189,35 @@ class BudgetPlanDetailCommon(BudgetControlCommon):
                     "plan_id": budget_plan.id,
                     "analytic_account_id": self.costcenter1.id,
                     "fund_id": self.fund2_g1.id,
+                    "analytic_tag_ids": [(4, self.analytic_tag1.id)],
+                    "allocated_amount": amount,
+                },
+                {
+                    "plan_id": budget_plan.id,
+                    "analytic_account_id": self.costcenter1.id,
+                    "fund_id": self.fund2_g1.id,
+                    "allocated_amount": amount,
+                },
+                # Line 5 - 8
+                {
+                    "plan_id": budget_plan.id,
+                    "analytic_account_id": self.costcenterX.id,
+                    "fund_id": self.fund1_g1.id,
+                    "analytic_tag_ids": [(4, self.analytic_tag1.id)],
+                    "allocated_amount": amount,
+                },
+                {
+                    "plan_id": budget_plan.id,
+                    "analytic_account_id": self.costcenterX.id,
+                    "fund_id": self.fund2_g1.id,
+                    "analytic_tag_ids": [(4, self.analytic_tag1.id)],
+                    "allocated_amount": amount,
+                },
+                {
+                    "plan_id": budget_plan.id,
+                    "analytic_account_id": self.costcenterX.id,
+                    "fund_id": self.fund2_g1.id,
+                    "analytic_tag_ids": [(4, self.analytic_tag2.id)],
                     "allocated_amount": amount,
                 },
                 {
@@ -155,4 +229,7 @@ class BudgetPlanDetailCommon(BudgetControlCommon):
             ]
         # Create budget plan line detail
         self.PlanLineDetail.create(lines_detail)
+        # Update Plan line and Detail
+        if auto_confirm:
+            budget_plan.action_confirm_plan_detail()
         return budget_plan

--- a/budget_plan_detail/tests/test_budget_plan_detail.py
+++ b/budget_plan_detail/tests/test_budget_plan_detail.py
@@ -4,7 +4,6 @@
 
 from freezegun import freeze_time
 
-from odoo import Command
 from odoo.exceptions import UserError
 from odoo.tests import tagged
 
@@ -54,10 +53,10 @@ class TestBudgetPlanDetail(BudgetPlanDetailCommon):
         self.assertFalse(self.budget_plan.line_detail_ids)
         self.assertFalse(self.budget_plan.line_ids)
 
-        self._create_budget_plan_line_detail(self.budget_plan)
+        self._create_budget_plan_line_detail(self.budget_plan, auto_confirm=False)
 
-        self.assertAlmostEqual(self.budget_plan.total_amount, 2400.0)
-        self.assertEqual(len(self.budget_plan.line_detail_ids), 4)
+        self.assertAlmostEqual(self.budget_plan.total_amount, 4800.0)
+        self.assertEqual(len(self.budget_plan.line_detail_ids), 8)
         self.assertFalse(self.budget_plan.is_confirm_plan)
         # Budget Plan line still not created (first time)
         self.assertFalse(self.budget_plan.line_ids)
@@ -80,7 +79,7 @@ class TestBudgetPlanDetail(BudgetPlanDetailCommon):
 
         # After confirm detail, plan line should be created
         self.assertTrue(self.budget_plan.is_confirm_plan)
-        self.assertEqual(len(self.budget_plan.line_detail_ids), 4)
+        self.assertEqual(len(self.budget_plan.line_detail_ids), 8)
         self.assertEqual(len(self.budget_plan.line_ids), 2)
 
         # Check Link button budget plan to budget plan detail
@@ -158,7 +157,11 @@ class TestBudgetPlanDetail(BudgetPlanDetailCommon):
 
         # Refresh data and Prepare budget control
         self.budget_plan.invalidate_recordset()
-        # Get 1 budget control, Costcenter1 has 3 plan detail (600, 600, 600)
+        # Get 1 budget control, Costcenter1 has 4 plan detail by default
+        # line 1: Costcenter1, Fund1, Tag1, 600.0
+        # line 2: Costcenter1, Fund1, Tag2, 600.0
+        # line 3: Costcenter1, Fund2, Tag1, 600.0
+        # line 4: Costcenter1, Fund2,     , 600.0
         budget_control = self.budget_plan.budget_control_ids[0]
         budget_control.template_line_ids = [
             self.template_line1.id,
@@ -170,11 +173,11 @@ class TestBudgetPlanDetail(BudgetPlanDetailCommon):
         budget_control.prepare_budget_control_matrix()
         assert len(budget_control.line_ids) == 12
         # Costcenter1 has 3 plan detail
-        # Assign budget.control amount: KPI1 = 1500, 200, 100
+        # Assign budget.control amount: KPI1 = 1500, 500, 400
         bc_items = budget_control.line_ids.filtered(lambda x: x.kpi_id == self.kpi1)
         bc_items[0].write({"amount": 1500})
-        bc_items[1].write({"amount": 200})
-        bc_items[2].write({"amount": 100})
+        bc_items[1].write({"amount": 500})
+        bc_items[2].write({"amount": 400})
 
         self.assertEqual(
             budget_control.mapped("plan_line_detail_ids"),
@@ -240,18 +243,20 @@ class TestBudgetPlanDetail(BudgetPlanDetailCommon):
     @freeze_time("2001-02-01")
     def test_05_transfer_budget_control(self):
         # budget control is depends on budget allocation
-        self._create_budget_plan_line_detail(self.budget_plan)
+        self._create_budget_plan_line_detail(self.budget_plan, auto_confirm=False)
         self.budget_plan.action_confirm_plan_detail()
         self.budget_plan.action_confirm()
         self.assertEqual(self.budget_plan.state, "confirm")
         self.budget_plan.action_create_update_budget_control()
         self.budget_plan.action_done()
 
+        self.assertEqual(len(self.budget_plan.line_ids), 2)
         self.assertEqual(self.budget_plan.state, "done")
 
         # Refresh data and Prepare budget control
         self.budget_plan.invalidate_recordset()
         budget_control_ids = self.budget_plan.budget_control_ids
+        self.assertEqual(len(budget_control_ids), 2)
         for bc in budget_control_ids:
             bc.template_line_ids = [
                 self.template_line1.id,
@@ -263,18 +268,10 @@ class TestBudgetPlanDetail(BudgetPlanDetailCommon):
             bc.prepare_budget_control_matrix()
             assert len(bc.line_ids) == 12
             bc_items = bc.line_ids.filtered(lambda x: x.kpi_id == self.kpi1)
-            if bc.allocated_amount == 1800.0:
-                # Costcenter1 has 3 plan detail
-                # Assign budget.control amount: KPI1 = 1500, 200, 100
-                bc_items[0].write({"amount": 1500})
-                bc_items[1].write({"amount": 200})
-                bc_items[2].write({"amount": 100})
-            else:
-                # CostcenterX has 1 plan detail
-                # Assign budget.control amount: KPI1 = 300, 200, 100
-                bc_items[0].write({"amount": 300})
-                bc_items[1].write({"amount": 200})
-                bc_items[2].write({"amount": 100})
+            # Assign budget.control amount: KPI1 = 1500, 500, 400
+            bc_items[0].write({"amount": 1500})
+            bc_items[1].write({"amount": 500})
+            bc_items[2].write({"amount": 400})
 
         self.assertEqual(budget_control_ids[0].diff_amount, 0.0)
         self.assertEqual(budget_control_ids[1].diff_amount, 0.0)
@@ -282,32 +279,22 @@ class TestBudgetPlanDetail(BudgetPlanDetailCommon):
         # Config dimension by sequence
         self.tag_dimension1.write({"by_sequence": True, "sequence": 1})
 
-        # Transfer budget amount from line4 to line1
+        # Transfer budget amount from line5 to line1
+        # But test line 1 is selected analytic tags wrong
         # line 1: Costcenter1, Fund1, Tag1, 600.0
-        # line 4: CostcenterX, Fund1,     , 600.0
-        transfer = self.BudgetTransfer.create(
-            {
-                "transfer_item_ids": [
-                    Command.create(
-                        {
-                            # Budget From
-                            "budget_control_from_id": budget_control_ids[1].id,
-                            "fund_from_id": self.fund1_g1.id,
-                            # Budget To (Test without analytic tag)
-                            "budget_control_to_id": budget_control_ids[0].id,
-                            "fund_to_id": self.fund1_g1.id,
-                            "amount": 500.0,
-                        }
-                    )
-                ]
-            }
+        # line 5: CostcenterX, Fund1, Tag1, 600.0
+        transfer = self._create_budget_transfer(
+            budget_control_ids[1], budget_control_ids[0], 500.0, analytic_tag_to=[]
         )
+
         transfer_line = transfer.transfer_item_ids
-        # line 4 is correct
+        # line 5 is correct
         self.assertEqual(len(transfer_line.detail_line_from_ids), 1)
         self.assertIn(transfer_line.fund_from_id, transfer_line.fund_from_all)
-        self.assertFalse(transfer_line.analytic_tag_from_ids)
-        self.assertFalse(transfer_line.analytic_tag_from_all)
+        self.assertEqual(transfer_line.analytic_tag_from_ids, self.analytic_tag1)
+        self.assertEqual(
+            transfer_line.analytic_tag_from_all, self.analytic_tag1 + self.analytic_tag2
+        )
         self.assertTrue(transfer_line.domain_tag_from_ids)
         self.assertAlmostEqual(transfer_line.amount_from_available, 600.0)
         # line 1 must not found detail lines, amount will 0.0 too

--- a/budget_plan_detail_advance_clearing/tests/test_budget_plan_detail_advance.py
+++ b/budget_plan_detail_advance_clearing/tests/test_budget_plan_detail_advance.py
@@ -55,8 +55,12 @@ class TestBudgetPlanDetailAdvance(TestBudgetPlanDetail):
         """Create same analytic, difference fund, difference analytic tags
         line 1: Costcenter1, Fund1, Tag1, 600.0
         line 2: Costcenter1, Fund1, Tag2, 600.0
-        line 3: Costcenter1, Fund2,     , 600.0
-        line 4: CostcenterX, Fund1,     , 600.0
+        line 3: Costcenter1, Fund2, Tag1, 600.0
+        line 4: Costcenter1, Fund2,     , 600.0
+        line 5: CostcenterX, Fund1, Tag1, 600.0
+        line 6: CostcenterX, Fund2, Tag1, 600.0
+        line 7: CostcenterX, Fund2, Tag2, 600.0
+        line 8: CostcenterX, Fund1,     , 600.0
         """
         self._create_budget_plan_line_detail(self.budget_plan)
         self.budget_plan.action_confirm_plan_detail()
@@ -69,7 +73,7 @@ class TestBudgetPlanDetailAdvance(TestBudgetPlanDetail):
 
         # Refresh data and Prepare budget control
         self.budget_plan.invalidate_recordset()
-        # Get 1 budget control, Costcenter1 has 3 plan detail (600, 600, 600)
+        # Get 1 budget control, Costcenter1 has 4 plan detail
         budget_control = self.budget_plan.budget_control_ids[0]
         budget_control.template_line_ids = [
             self.template_line1.id,
@@ -82,11 +86,11 @@ class TestBudgetPlanDetailAdvance(TestBudgetPlanDetail):
         budget_control.prepare_budget_control_matrix()
         assert len(budget_control.line_ids) == 16
         # Costcenter1 has 3 plan detail
-        # Assign budget.control amount: KPI1 = 1500, 200, 100
+        # Assign budget.control amount: KPI1 = 1500, 500, 400
         bc_items = budget_control.line_ids.filtered(lambda x: x.kpi_id == self.kpiAV)
         bc_items[0].write({"amount": 1500})
-        bc_items[1].write({"amount": 200})
-        bc_items[2].write({"amount": 100})
+        bc_items[1].write({"amount": 500})
+        bc_items[2].write({"amount": 400})
 
         self.assertEqual(
             budget_control.mapped("plan_line_detail_ids"),
@@ -145,7 +149,7 @@ class TestBudgetPlanDetailAdvance(TestBudgetPlanDetail):
         self.assertEqual(move.invoice_line_ids.analytic_tag_ids, self.analytic_tag1)
         self.assertAlmostEqual(budget_control.amount_advance, 400.0)
         self.assertAlmostEqual(budget_control.amount_expense, 0.0)
-        self.assertAlmostEqual(budget_control.amount_balance, 1400.0)
+        self.assertAlmostEqual(budget_control.amount_balance, 2000.0)
 
         # Post journal entry
         advance_sheet.action_sheet_move_post()
@@ -153,7 +157,7 @@ class TestBudgetPlanDetailAdvance(TestBudgetPlanDetail):
 
         self.assertAlmostEqual(budget_control.amount_advance, 400.0)
         self.assertAlmostEqual(budget_control.amount_expense, 0.0)
-        self.assertAlmostEqual(budget_control.amount_balance, 1400.0)
+        self.assertAlmostEqual(budget_control.amount_balance, 2000.0)
 
         # Make payment full amount = 400
         advance_sheet.action_register_payment()
@@ -168,7 +172,7 @@ class TestBudgetPlanDetailAdvance(TestBudgetPlanDetail):
         self.assertAlmostEqual(advance_sheet.clearing_residual, 400.0)
         self.assertAlmostEqual(budget_control.amount_advance, 400.0)
         self.assertAlmostEqual(budget_control.amount_expense, 0.0)
-        self.assertAlmostEqual(budget_control.amount_balance, 1400.0)
+        self.assertAlmostEqual(budget_control.amount_balance, 2000.0)
 
         # Clearing Advance
         user = self.env.ref("base.user_admin")
@@ -199,4 +203,4 @@ class TestBudgetPlanDetailAdvance(TestBudgetPlanDetail):
         self.assertAlmostEqual(advance_sheet.clearing_residual, 400.0)
         self.assertAlmostEqual(budget_control.amount_advance, 340.0)
         self.assertAlmostEqual(budget_control.amount_expense, 60.0)
-        self.assertAlmostEqual(budget_control.amount_balance, 1400.0)
+        self.assertAlmostEqual(budget_control.amount_balance, 2000.0)

--- a/budget_plan_detail_expense/tests/test_budget_plan_detail_expense.py
+++ b/budget_plan_detail_expense/tests/test_budget_plan_detail_expense.py
@@ -48,8 +48,12 @@ class TestBudgetPlanDetailExpense(TestBudgetPlanDetail):
         """Create same analytic, difference fund, difference analytic tags
         line 1: Costcenter1, Fund1, Tag1, 600.0
         line 2: Costcenter1, Fund1, Tag2, 600.0
-        line 3: Costcenter1, Fund2,     , 600.0
-        line 4: CostcenterX, Fund1,     , 600.0
+        line 3: Costcenter1, Fund2, Tag1, 600.0
+        line 4: Costcenter1, Fund2,     , 600.0
+        line 5: CostcenterX, Fund1, Tag1, 600.0
+        line 6: CostcenterX, Fund2, Tag1, 600.0
+        line 7: CostcenterX, Fund2, Tag2, 600.0
+        line 8: CostcenterX, Fund1,     , 600.0
         """
         self._create_budget_plan_line_detail(self.budget_plan)
         self.budget_plan.action_confirm_plan_detail()
@@ -62,7 +66,7 @@ class TestBudgetPlanDetailExpense(TestBudgetPlanDetail):
 
         # Refresh data and Prepare budget control
         self.budget_plan.invalidate_recordset()
-        # Get 1 budget control, Costcenter1 has 3 plan detail (600, 600, 600)
+        # Get 1 budget control, Costcenter1 has 4 plan detail
         budget_control = self.budget_plan.budget_control_ids[0]
         budget_control.template_line_ids = [
             self.template_line1.id,
@@ -74,11 +78,11 @@ class TestBudgetPlanDetailExpense(TestBudgetPlanDetail):
         budget_control.prepare_budget_control_matrix()
         assert len(budget_control.line_ids) == 12
         # Costcenter1 has 3 plan detail
-        # Assign budget.control amount: KPI1 = 1500, 200, 100
+        # Assign budget.control amount: KPI1 = 1500, 500, 400
         bc_items = budget_control.line_ids.filtered(lambda x: x.kpi_id == self.kpi1)
         bc_items[0].write({"amount": 1500})
-        bc_items[1].write({"amount": 200})
-        bc_items[2].write({"amount": 100})
+        bc_items[1].write({"amount": 500})
+        bc_items[2].write({"amount": 400})
 
         self.assertEqual(
             budget_control.mapped("plan_line_detail_ids"),
@@ -92,7 +96,7 @@ class TestBudgetPlanDetailExpense(TestBudgetPlanDetail):
         budget_control.action_done()
         self.budget_period.control_budget = True
 
-        # We allocate budget to Costcenter1 each 600.0 (total is 1800.0)
+        # We allocate budget to Costcenter1 each 600.0 (total is 2400.0)
         analytic_distribution = {self.costcenter1.id: 100}
 
         # Commit expense without allocation (no fund, no tags)
@@ -144,7 +148,7 @@ class TestBudgetPlanDetailExpense(TestBudgetPlanDetail):
         self.assertEqual(move.invoice_line_ids.analytic_tag_ids, self.analytic_tag1)
         self.assertAlmostEqual(budget_control.amount_expense, 400.0)
         self.assertAlmostEqual(budget_control.amount_actual, 0.0)
-        self.assertAlmostEqual(budget_control.amount_balance, 1400.0)
+        self.assertAlmostEqual(budget_control.amount_balance, 2000.0)
 
         # Post journal entry
         sheet.action_sheet_move_post()
@@ -152,4 +156,4 @@ class TestBudgetPlanDetailExpense(TestBudgetPlanDetail):
 
         self.assertAlmostEqual(budget_control.amount_expense, 0.0)
         self.assertAlmostEqual(budget_control.amount_actual, 400.0)
-        self.assertAlmostEqual(budget_control.amount_balance, 1400.0)
+        self.assertAlmostEqual(budget_control.amount_balance, 2000.0)

--- a/budget_plan_detail_purchase/models/purchase.py
+++ b/budget_plan_detail_purchase/models/purchase.py
@@ -7,7 +7,6 @@ from odoo import Command, models
 class PurchaseOrderLine(models.Model):
     _name = "purchase.order.line"
     _inherit = ["analytic.dimension.line", "purchase.order.line"]
-    _analytic_tag_field_name = "analytic_tag_ids"
 
     def _prepare_account_move_line(self, move=False):
         res = super()._prepare_account_move_line(move)

--- a/budget_plan_detail_purchase/tests/test_budget_plan_detail_purchase.py
+++ b/budget_plan_detail_purchase/tests/test_budget_plan_detail_purchase.py
@@ -46,8 +46,12 @@ class TestBudgetPlanDetailPurchase(TestBudgetPlanDetail):
         """Create same analytic, difference fund, difference analytic tags
         line 1: Costcenter1, Fund1, Tag1, 600.0
         line 2: Costcenter1, Fund1, Tag2, 600.0
-        line 3: Costcenter1, Fund2,     , 600.0
-        line 4: CostcenterX, Fund1,     , 600.0
+        line 3: Costcenter1, Fund2, Tag1, 600.0
+        line 4: Costcenter1, Fund2,     , 600.0
+        line 5: CostcenterX, Fund1, Tag1, 600.0
+        line 6: CostcenterX, Fund2, Tag1, 600.0
+        line 7: CostcenterX, Fund2, Tag2, 600.0
+        line 8: CostcenterX, Fund1,     , 600.0
         """
         self._create_budget_plan_line_detail(self.budget_plan)
         self.budget_plan.action_confirm_plan_detail()
@@ -60,7 +64,7 @@ class TestBudgetPlanDetailPurchase(TestBudgetPlanDetail):
 
         # Refresh data and Prepare budget control
         self.budget_plan.invalidate_recordset()
-        # Get 1 budget control, Costcenter1 has 3 plan detail (600, 600, 600)
+        # Get 1 budget control, Costcenter1 has 4 plan detail
         budget_control = self.budget_plan.budget_control_ids[0]
         budget_control.template_line_ids = [
             self.template_line1.id,
@@ -72,11 +76,11 @@ class TestBudgetPlanDetailPurchase(TestBudgetPlanDetail):
         budget_control.prepare_budget_control_matrix()
         assert len(budget_control.line_ids) == 12
         # Costcenter1 has 3 plan detail
-        # Assign budget.control amount: KPI1 = 1500, 200, 100
+        # Assign budget.control amount: KPI1 = 1500, 500, 400
         bc_items = budget_control.line_ids.filtered(lambda x: x.kpi_id == self.kpi1)
         bc_items[0].write({"amount": 1500})
-        bc_items[1].write({"amount": 200})
-        bc_items[2].write({"amount": 100})
+        bc_items[1].write({"amount": 500})
+        bc_items[2].write({"amount": 400})
 
         self.assertEqual(
             budget_control.mapped("plan_line_detail_ids"),
@@ -90,7 +94,7 @@ class TestBudgetPlanDetailPurchase(TestBudgetPlanDetail):
         budget_control.action_done()
         self.budget_period.control_budget = True
 
-        # We allocate budget to Costcenter1 each 600.0 (total is 1800.0)
+        # We allocate budget to Costcenter1 each 600.0 (total is 2400.0)
         analytic_distribution = {self.costcenter1.id: 100}
 
         # Commit purchase without allocation (no fund, no tags)

--- a/budget_plan_detail_purchase_request/tests/test_budget_plan_detail_purchase_request.py
+++ b/budget_plan_detail_purchase_request/tests/test_budget_plan_detail_purchase_request.py
@@ -43,8 +43,12 @@ class TestBudgetPlanDetailPurchaseRequest(TestBudgetPlanDetail):
         """Create same analytic, difference fund, difference analytic tags
         line 1: Costcenter1, Fund1, Tag1, 600.0
         line 2: Costcenter1, Fund1, Tag2, 600.0
-        line 3: Costcenter1, Fund2,     , 600.0
-        line 4: CostcenterX, Fund1,     , 600.0
+        line 3: Costcenter1, Fund2, Tag1, 600.0
+        line 4: Costcenter1, Fund2,     , 600.0
+        line 5: CostcenterX, Fund1, Tag1, 600.0
+        line 6: CostcenterX, Fund2, Tag1, 600.0
+        line 7: CostcenterX, Fund2, Tag2, 600.0
+        line 8: CostcenterX, Fund1,     , 600.0
         """
         self._create_budget_plan_line_detail(self.budget_plan)
         self.budget_plan.action_confirm_plan_detail()
@@ -57,7 +61,7 @@ class TestBudgetPlanDetailPurchaseRequest(TestBudgetPlanDetail):
 
         # Refresh data and Prepare budget control
         self.budget_plan.invalidate_recordset()
-        # Get 1 budget control, Costcenter1 has 3 plan detail (600, 600, 600)
+        # Get 1 budget control, Costcenter1 has 4 plan detail
         budget_control = self.budget_plan.budget_control_ids[0]
         budget_control.template_line_ids = [
             self.template_line1.id,
@@ -69,11 +73,11 @@ class TestBudgetPlanDetailPurchaseRequest(TestBudgetPlanDetail):
         budget_control.prepare_budget_control_matrix()
         assert len(budget_control.line_ids) == 12
         # Costcenter1 has 3 plan detail
-        # Assign budget.control amount: KPI1 = 1500, 200, 100
+        # Assign budget.control amount: KPI1 = 1500, 500, 400
         bc_items = budget_control.line_ids.filtered(lambda x: x.kpi_id == self.kpi1)
         bc_items[0].write({"amount": 1500})
-        bc_items[1].write({"amount": 200})
-        bc_items[2].write({"amount": 100})
+        bc_items[1].write({"amount": 500})
+        bc_items[2].write({"amount": 400})
 
         self.assertEqual(
             budget_control.mapped("plan_line_detail_ids"),
@@ -87,7 +91,7 @@ class TestBudgetPlanDetailPurchaseRequest(TestBudgetPlanDetail):
         budget_control.action_done()
         self.budget_period.control_budget = True
 
-        # We allocate budget to Costcenter1 each 600.0 (total is 1800.0)
+        # We allocate budget to Costcenter1 each 600.0 (total is 2400.0)
         analytic_distribution = {self.costcenter1.id: 100}
 
         # Commit purchase without allocation (no fund, no tags)
@@ -105,7 +109,7 @@ class TestBudgetPlanDetailPurchaseRequest(TestBudgetPlanDetail):
         purchase_request = purchase_request.with_context(
             force_date_commit=purchase_request.date_start
         )
-        self.assertAlmostEqual(budget_control.amount_balance, 1800.0)
+        self.assertAlmostEqual(budget_control.amount_balance, 2400.0)
 
         with self.assertRaisesRegex(
             UserError, "is not allocated on budget plan detail"
@@ -134,7 +138,7 @@ class TestBudgetPlanDetailPurchaseRequest(TestBudgetPlanDetail):
         )
         self.assertAlmostEqual(budget_control.amount_purchase_request, 400.0)
         self.assertAlmostEqual(budget_control.amount_purchase, 0.0)
-        self.assertAlmostEqual(budget_control.amount_balance, 1400.0)
+        self.assertAlmostEqual(budget_control.amount_balance, 2000.0)
 
         # Create PR from PO
         MakePO = self.env["purchase.request.line.make.purchase.order"]
@@ -172,4 +176,4 @@ class TestBudgetPlanDetailPurchaseRequest(TestBudgetPlanDetail):
 
         self.assertAlmostEqual(budget_control.amount_purchase_request, 0.0)
         self.assertAlmostEqual(budget_control.amount_purchase, 600.0)
-        self.assertAlmostEqual(budget_control.amount_balance, 1200.0)
+        self.assertAlmostEqual(budget_control.amount_balance, 1800.0)

--- a/budget_plan_detail_purchase_requisition/models/purchase_requisition.py
+++ b/budget_plan_detail_purchase_requisition/models/purchase_requisition.py
@@ -11,7 +11,6 @@ class PurchaseRequisitionLine(models.Model):
         "budget.docline.mixin.base",
         "purchase.requisition.line",
     ]
-    _analytic_tag_field_name = "analytic_tag_ids"
 
     analytic_tag_ids = fields.Many2many(
         comodel_name="account.analytic.tag",
@@ -30,17 +29,3 @@ class PurchaseRequisitionLine(models.Model):
         res["fund_id"] = self.fund_id.id
         res["analytic_tag_ids"] = [Command.set(self.analytic_tag_ids.ids)]
         return res
-
-    def _convert_analytics(self, analytic_distribution=False):
-        Analytic = self.env["account.analytic.account"]
-        analytics = analytic_distribution or self[self._budget_analytic_field]
-        if not analytics:
-            return Analytic
-        # Check analytic from distribution it send data with JSON type 'dict'
-        # and we need convert it to analytic object
-        if self._budget_analytic_field == "analytic_distribution":
-            account_analytic_ids = [
-                int(v) for k in analytics.keys() for v in k.split(",")
-            ]
-            analytics = Analytic.browse(account_analytic_ids)
-        return analytics

--- a/budget_plan_detail_purchase_requisition/tests/test_budget_plan_detail_purchase_requisition.py
+++ b/budget_plan_detail_purchase_requisition/tests/test_budget_plan_detail_purchase_requisition.py
@@ -23,8 +23,12 @@ class TestBudgetPlanDetailPurchaseRequisition(TestBudgetPlanDetailPurchaseReques
         """Create same analytic, difference fund, difference analytic tags
         line 1: Costcenter1, Fund1, Tag1, 600.0
         line 2: Costcenter1, Fund1, Tag2, 600.0
-        line 3: Costcenter1, Fund2,     , 600.0
-        line 4: CostcenterX, Fund1,     , 600.0
+        line 3: Costcenter1, Fund2, Tag1, 600.0
+        line 4: Costcenter1, Fund2,     , 600.0
+        line 5: CostcenterX, Fund1, Tag1, 600.0
+        line 6: CostcenterX, Fund2, Tag1, 600.0
+        line 7: CostcenterX, Fund2, Tag2, 600.0
+        line 8: CostcenterX, Fund1,     , 600.0
         """
         self._create_budget_plan_line_detail(self.budget_plan)
         self.budget_plan.action_confirm_plan_detail()
@@ -37,7 +41,7 @@ class TestBudgetPlanDetailPurchaseRequisition(TestBudgetPlanDetailPurchaseReques
 
         # Refresh data and Prepare budget control
         self.budget_plan.invalidate_recordset()
-        # Get 1 budget control, Costcenter1 has 3 plan detail (600, 600, 600)
+        # Get 1 budget control, Costcenter1 has 4 plan detail
         budget_control = self.budget_plan.budget_control_ids[0]
         budget_control.template_line_ids = [
             self.template_line1.id,
@@ -49,11 +53,11 @@ class TestBudgetPlanDetailPurchaseRequisition(TestBudgetPlanDetailPurchaseReques
         budget_control.prepare_budget_control_matrix()
         assert len(budget_control.line_ids) == 12
         # Costcenter1 has 3 plan detail
-        # Assign budget.control amount: KPI1 = 1500, 200, 100
+        # Assign budget.control amount: KPI1 = 1500, 500, 400
         bc_items = budget_control.line_ids.filtered(lambda x: x.kpi_id == self.kpi1)
         bc_items[0].write({"amount": 1500})
-        bc_items[1].write({"amount": 200})
-        bc_items[2].write({"amount": 100})
+        bc_items[1].write({"amount": 500})
+        bc_items[2].write({"amount": 400})
 
         self.assertEqual(
             budget_control.mapped("plan_line_detail_ids"),
@@ -67,7 +71,7 @@ class TestBudgetPlanDetailPurchaseRequisition(TestBudgetPlanDetailPurchaseReques
         budget_control.action_done()
         self.budget_period.control_budget = True
 
-        # We allocate budget to Costcenter1 each 600.0 (total is 1800.0)
+        # We allocate budget to Costcenter1 each 600.0 (total is 2400.0)
         analytic_distribution = {self.costcenter1.id: 100}
 
         # Commit purchase without allocation (no fund, no tags)
@@ -90,7 +94,7 @@ class TestBudgetPlanDetailPurchaseRequisition(TestBudgetPlanDetailPurchaseReques
         purchase_request = purchase_request.with_context(
             force_date_commit=purchase_request.date_start
         )
-        self.assertAlmostEqual(budget_control.amount_balance, 1800.0)
+        self.assertAlmostEqual(budget_control.amount_balance, 2400.0)
 
         purchase_request.button_to_approve()
         purchase_request.button_approved()
@@ -101,7 +105,7 @@ class TestBudgetPlanDetailPurchaseRequisition(TestBudgetPlanDetailPurchaseReques
         )
         self.assertAlmostEqual(budget_control.amount_purchase_request, 400.0)
         self.assertAlmostEqual(budget_control.amount_purchase, 0.0)
-        self.assertAlmostEqual(budget_control.amount_balance, 1400.0)
+        self.assertAlmostEqual(budget_control.amount_balance, 2000.0)
 
         # Create Purchase Agreement from PR
         wiz = self.pr_te_wiz.with_context(


### PR DESCRIPTION
- Move `_convert_analytics` to `budget.docline.mixin.base`
- Remove _budget_analytic_field and _analytic_tag_field_name because all module use same name