### PR TITLE
[15.0][IMP] budget_control: install module with large database

### DIFF
--- a/budget_control/models/account_move_line.py
+++ b/budget_control/models/account_move_line.py
@@ -11,9 +11,7 @@ class AccountMoveLine(models.Model):
     _budget_move_model = "account.budget.move"
     _doc_rel = "move_id"
 
-    can_commit = fields.Boolean(
-        compute="_compute_can_commit",
-    )
+    can_commit = fields.Boolean(store=True)
     budget_move_ids = fields.One2many(
         comodel_name="account.budget.move",
         inverse_name="move_line_id",
@@ -21,14 +19,23 @@ class AccountMoveLine(models.Model):
     )
     return_amount_commit = fields.Boolean(
         related="move_id.return_amount_commit",
+        store=True,
     )
 
-    @api.depends()
+    @api.depends("move_id.not_affect_budget", "analytic_account_id")
     def _compute_can_commit(self):
-        res = super()._compute_can_commit()
-        no_budget_moves = self.mapped("move_id").filtered("not_affect_budget")
-        no_budget_moves.mapped("line_ids").update({"can_commit": False})
-        return res
+        """Overwrite this main method to spped-up performance,
+        and Skip compute when install this module first time.
+        """
+        if self.env.context.get("module") == "budget_control":
+            return
+
+        for rec in self:
+            if rec.move_id.not_affect_budget:
+                rec.can_commit = False
+                continue
+
+            rec.can_commit = bool(rec.analytic_account_id)
 
     def recompute_budget_move(self):
         for invoice_line in self:

--- a/budget_control/models/base_budget_move.py
+++ b/budget_control/models/base_budget_move.py
@@ -7,6 +7,8 @@ from json import dumps
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError, ValidationError
 
+ADDON = "budget_control"
+
 
 class BaseBudgetMove(models.AbstractModel):
     _name = "base.budget.move"
@@ -183,6 +185,9 @@ class BudgetDoclineMixin(models.AbstractModel):
 
     @api.depends(lambda self: [self._budget_analytic_field])
     def _compute_auto_adjust_date_commit(self):
+        if self.env.context.get("module") == ADDON:
+            return
+
         for docline in self:
             docline.auto_adjust_date_commit = docline[
                 self._budget_analytic_field
@@ -191,6 +196,9 @@ class BudgetDoclineMixin(models.AbstractModel):
     @api.depends()
     def _compute_can_commit(self):
         """Determine if this document is eligible for budget commitment."""
+        if self.env.context.get("module") == ADDON:
+            return
+
         # All required fields are set
         required_fields = self._required_fields_to_commit()
         domain = [(field, "!=", False) for field in required_fields]
@@ -210,6 +218,9 @@ class BudgetDoclineMixin(models.AbstractModel):
         - Calc amount_commit from all budget_move_ids
         - Calc date_commit if not exists and on 1st budget_move_ids only or False
         """
+        if self.env.context.get("module") == ADDON:
+            return
+
         for rec in self:
             debit = sum(rec.budget_move_ids.mapped("debit"))
             credit = sum(rec.budget_move_ids.mapped("credit"))
@@ -220,6 +231,9 @@ class BudgetDoclineMixin(models.AbstractModel):
                 rec.date_commit = rec.date_commit
 
     def _compute_json_budget_popover(self):
+        if self.env.context.get("module") == ADDON:
+            return
+
         FloatConverter = self.env["ir.qweb.field.float"]
         for rec in self:
             analytic = rec[self._budget_analytic_field]


### PR DESCRIPTION
Can't install module budget_control when we have account.move.line 5M records.
This PR fixed performance for install module only