### PR TITLE
[15.0][FIX] budget_control_advance_clearing: commit wrong budget when multi lines clearing

### DIFF
--- a/budget_control_advance_clearing/models/hr_expense.py
+++ b/budget_control_advance_clearing/models/hr_expense.py
@@ -137,8 +137,10 @@ class HRExpense(models.Model):
                 advance = reconcile.debit_move_id.expense_id
                 amount_return = reconcile.debit_amount_currency
                 # Credit side (Return Advance)
-                return_ml = reconcile.credit_move_id
-                if advance:
+                return_ml = reconcile.credit_move_id.filtered(
+                    lambda line: line.payment_id
+                )
+                if advance and return_ml:
                     advance.commit_budget(
                         reverse=True,
                         amount_currency=amount_return,

--- a/budget_control_advance_clearing/views/hr_expense_view.xml
+++ b/budget_control_advance_clearing/views/hr_expense_view.xml
@@ -53,6 +53,7 @@
                     <field name="advance_budget_move_ids" readonly="1">
                         <tree>
                             <field name="expense_id" optional="show" />
+                            <field name="clearing_id" optional="show" />
                             <field name="move_id" />
                             <field name="date" />
                             <field name="analytic_group" optional="show" />


### PR DESCRIPTION
Step to test:
1. Create advance multi line
2. Clearing multi line > Post Journal
3. Back to advance and recompute advance, it will commit budget duplicate