### PR TITLE
[FIX] budget allocation: get budget only period

### DIFF
--- a/budget_allocation/report/budget_source_fund_report.py
+++ b/budget_allocation/report/budget_source_fund_report.py
@@ -169,7 +169,10 @@ class SourceFundMonitorReport(models.Model):
         """
 
     def _where_budget(self):
-        return "where sf.active is true and ba.active is true and bc.active is true"
+        return (
+            "where sf.active is true and ba.active is true and bc.active is true "
+            "and ba.budget_period_id = bp.id"
+        )
 
     def _select_statement(self, amount_type):
         return self._get_select_amount_types()[amount_type]


### PR DESCRIPTION
แก้ไขปัญหาระบบดึง Budget เพื่อใช้ตรวจสอบงบประมาณไม่ถูกต้อง

AA : ฝ่ายกลยุทธ์

ปี 2024
fund : แผนงานพื้นฐาน : 20,000.00 บาท

ปี 2025 
fund : แผนงานพื้นฐาน : 30,000.00 บาท

ปี 2026
fund : แผนงานยุทธศาสตร์ : 100,000.00 บาท

ก่อนแก้ไข 
ระบบจะแสดง Budget โดยนำยอดของทั้ง 3 ปีมารวมกัน

 ปี 2024, 2025, 2026 มีงบประมาณ 20,000.00 + 30,000.00 + 100,000.00 = 150,000 บาท
โดยแบ่งเป็น
- แผนงานพื้นฐาน 50,000 บาท 
- แผนงานยุทธศาสตร์ 100,000.00 บาท

หลังแก้ไข
 ปี 2024 มีงบประมาณ 20,000.00 บาท
โดยแบ่งเป็น
- แผนงานพื้นฐาน 20,000 บาท 
- แผนงานยุทธศาสตร์ 0.00 บาท

 ปี 2025 มีงบประมาณ 30,000.00 บาท
โดยแบ่งเป็น
- แผนงานพื้นฐาน 30,000 บาท 
- แผนงานยุทธศาสตร์ 0.00 บาท

 ปี 2026 มีงบประมาณ 100,000.00 บาท
โดยแบ่งเป็น
- แผนงานพื้นฐาน 0.00 บาท 
- แผนงานยุทธศาสตร์ 100,000.00 บาท




