### PR TITLE
[15.0][FIX] budget_control_purchase: remove flush

### DIFF
--- a/budget_control_purchase/models/purchase.py
+++ b/budget_control_purchase/models/purchase.py
@@ -43,7 +43,6 @@ class PurchaseOrder(models.Model):
 
     def button_confirm(self):
         res = super().button_confirm()
-        self.flush()
         BudgetPeriod = self.env["budget.period"]
         for doc in self.filtered(lambda l: l.state == "purchase"):
             BudgetPeriod.check_budget(doc.order_line, doc_type="purchase")


### PR DESCRIPTION
When use `base_tier_validation_server_action` and `base_tier_validation_report`. after auto approve. it will error

