### PR TITLE
[15.0][FIX] budget_control_request_document_expense: uncommit RQ before submit EX

### DIFF
--- a/budget_control_request_document_expense/models/__init__.py
+++ b/budget_control_request_document_expense/models/__init__.py
@@ -4,3 +4,4 @@ from . import base_budget_move
 from . import request_document
 from . import request_order
 from . import hr_expense
+from . import budget_period

--- a/budget_control_request_document_expense/models/budget_period.py
+++ b/budget_control_request_document_expense/models/budget_period.py
@@ -1,0 +1,24 @@
+# Copyright 2026 Ecosoft Co., Ltd. (http://ecosoft.co.th)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import api, models
+
+
+class BudgetPeriod(models.Model):
+    _inherit = "budget.period"
+
+    @api.model
+    def check_budget_precommit(self, doclines, doc_type="account"):
+        budget_moves = False
+        if doclines._name == "hr.expense":
+            request_documents = doclines.mapped("sheet_id.request_document_id")
+            if request_documents:
+                budget_moves = request_documents.budget_move_ids
+                request_documents.with_context(
+                    force_commit=True, check_budget_precommit=True
+                ).uncommit_request_budget(doclines)
+                budget_moves = request_documents.budget_move_ids - budget_moves
+        res = super().check_budget_precommit(doclines, doc_type=doc_type)
+        if budget_moves:
+            budget_moves.unlink()
+        return res

--- a/budget_control_request_document_expense/models/request_document.py
+++ b/budget_control_request_document_expense/models/request_document.py
@@ -20,6 +20,7 @@ class RequestDocument(models.Model):
             request_line._name == "hr.expense"
             and budget_move
             and request_line[request_line._doc_rel].state in ["approve", "post", "done"]
+            or self.env.context("check_budget_precommit", False)
         ):
             self.close_budget_move()
         return res


### PR DESCRIPTION
แก้ไขระบบให้ uncommit request ก่อน precommit ex

STEP TO ERROR
- สร้าง RQ และขออนุมัติตาม Flow ปกติ
- ผู้อนุมัติคนสุดท้ายอนุมัติ => ระบบ Summit EX และ Check Budget Pre commit 

สาเหตุเกิดจาก
- เมื่อ Check Budget Pre commit ระบบไม่คืน Commit ที่ RQ ทำให้งบประมาณไม่เพียงพอ

การแก้ไข
- เมื่อ Pre commit ให้ระบบคืนงบประมาณของ RQ ชั่วคราว ถ้า EX submit ไม่ผ่าน ระบบ Commit ที่ RQ ตามเดิม