### PR TITLE
[15.0][FIX] budget_control_expense: check_over_returned_budget only ml debit

### DIFF
--- a/budget_control_expense/models/account_move_line.py
+++ b/budget_control_expense/models/account_move_line.py
@@ -22,7 +22,7 @@ class AccountMoveLine(models.Model):
     def uncommit_expense_budget(self):
         """Uncommit the budget for related expenses when the vendor bill is in a valid state."""
         Expense = self.env["hr.expense"]
-        for ml in self:
+        for ml in self.filtered(lambda l: l.debit > 0):
             inv_state = ml.move_id.state
             move_type = ml.move_id.move_type
             if move_type != "entry":

--- a/budget_control_expense/models/account_move_line.py
+++ b/budget_control_expense/models/account_move_line.py
@@ -22,7 +22,8 @@ class AccountMoveLine(models.Model):
     def uncommit_expense_budget(self):
         """Uncommit the budget for related expenses when the vendor bill is in a valid state."""
         Expense = self.env["hr.expense"]
-        for ml in self.filtered(lambda l: l.debit > 0):
+        for ml in self:
+            account = ml.account_id
             inv_state = ml.move_id.state
             move_type = ml.move_id.move_type
             if move_type != "entry":
@@ -30,7 +31,7 @@ class AccountMoveLine(models.Model):
             if inv_state == "posted":
                 expense = ml.expense_id.filtered("amount_commit")
                 # Because this is not invoice, we need to compare account
-                if not expense:
+                if not expense or expense.account_id != account:
                     continue
                 # Also test for future advance extension, never uncommit for advance
                 if hasattr(expense, "advance") and expense["advance"]:


### PR DESCRIPTION
แก้ไขบัค ขณะ uncommit expense budget เมื่อรันแล้ว reverse budget move ซ้ำ expense line เดียวกัน

ตัวอย่าง
expense sheet มี 2 ex line ผมรวมเป็น 150 บาท

เมื่อกด Post JV ระบบสร้าง ml 4 บรรทัด ได้แก่
ml 1 expense account ฝั่ง debit ของ ex line 1 100 บาท
ml 2 payable account ฝั่ง credit ของ ex line 1 100 บาท
ml 3 expense account ฝั่ง debit ของ ex line 2 50 บาท
ml 4 payable account ฝั่ง credit ของ ex line 2 50 บาท

เมื่อระบบสร้าง reverse
สร้าง reverse ของ ml 1 100 บาท
สร้าง reverse ของ ml 2 100 บาท

ทำให้ reverse เกิน 150 บาท ทำให้ฟังชั่นวนทำงานวนไปเรื่อยๆ จนเป็น while loop

การแก้ไข
ผมแก้ไขให้ระบบ check เฉพาะ ml ฝั่ง debit เท่านั้นเพื่อให้ไม่เกิดการ reverse ซ้ำ
