### PR TITLE
[18.0][FIX] budget_control_purchase_request: fix error when no choose analytic in line

### DIFF
--- a/budget_control_purchase_request/wizards/purchase_request_line_make_purchase_order.py
+++ b/budget_control_purchase_request/wizards/purchase_request_line_make_purchase_order.py
@@ -27,7 +27,7 @@ class PurchaseRequestLineMakePurchaseOrder(models.TransientModel):
         fy_dates = item.line_id.company_id.compute_fiscalyear_dates(
             fields.Date.context_today(self)
         )
-        if item.line_id.date_commit > fy_dates["date_to"]:
+        if item.line_id.date_commit and item.line_id.date_commit > fy_dates["date_to"]:
             vals["date_commit"] = item.line_id.date_commit
         return vals
 


### PR DESCRIPTION
Step to test:
1. Create Purchase Request and add line **without analytic**
2. Create RFQ > It will error