### PR TITLE
[18.0][IMP] budget_control: by pass check budget on account or period

### DIFF
--- a/budget_control/__manifest__.py
+++ b/budget_control/__manifest__.py
@@ -3,7 +3,7 @@
 
 {
     "name": "Budget Control",
-    "version": "18.0.1.4.4",
+    "version": "18.0.1.5.4",
     "category": "Accounting",
     "license": "AGPL-3",
     "author": "Ecosoft, Odoo Community Association (OCA)",
@@ -46,6 +46,7 @@
         "views/budget_commit_forward_view.xml",
         "views/budget_balance_forward_view.xml",
         # Account Module
+        "views/account_account_view.xml",
         "views/account_budget_move.xml",
         "views/account_journal_view.xml",
         "views/account_move_views.xml",

--- a/budget_control/models/__init__.py
+++ b/budget_control/models/__init__.py
@@ -23,6 +23,7 @@ from . import budget_commit_forward
 from . import budget_balance_forward
 
 # Account Module
+from . import account_account
 from . import account_journal
 from . import account_budget_move
 from . import account_move

--- a/budget_control/models/account_account.py
+++ b/budget_control/models/account_account.py
@@ -1,0 +1,14 @@
+# Copyright 2026 Ecosoft Co., Ltd. (http://ecosoft.co.th)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class AccountAccount(models.Model):
+    _inherit = "account.account"
+
+    budget_bypass = fields.Boolean(
+        string="Bypass Budget Control",
+        help="When enabled, transactions using this account will skip budget "
+        "control checks even if the analytic account is budget-controlled.",
+    )

--- a/budget_control/models/base_budget_move.py
+++ b/budget_control/models/base_budget_move.py
@@ -410,8 +410,10 @@ class BudgetDoclineMixin(models.AbstractModel):
         # Get KPI, when possible.
         if controls and template_lines:
             template_line = BudgetPeriod._get_kpi_by_control_key(
-                template_lines, controls[0]
+                template_lines, controls[0], budget_period=budget_period
             )
+            if not template_line:
+                return budget_move
             budget_move.template_line_id = template_line.id
             # Set KPI for check budget
             budget_move.kpi_id = template_line.kpi_id.id

--- a/budget_control/models/budget_period.py
+++ b/budget_control/models/budget_period.py
@@ -73,10 +73,18 @@ class BudgetPeriod(models.Model):
         help="Budget control sheet in this budget control year, will use this "
         "data range to plan the budget.",
     )
-    # analytic_ids = fields.One2many(
-    #     comodel_name="account.analytic.account",
-    #     inverse_name="budget_period_id",
-    # )
+    unmatched_account_policy = fields.Selection(
+        selection=[
+            ("error", "Block (must be in template)"),
+            ("skip", "Allow (pass through)"),
+        ],
+        default="error",
+        required=True,
+        tracking=True,
+        help="Policy when a transaction account is not found in the budget template.\n"
+        "- Block: raise an error (strict mode)\n"
+        "- Allow: skip budget check and let the transaction pass through",
+    )
 
     @api.model
     def default_get(self, default_fields):
@@ -314,6 +322,8 @@ class BudgetPeriod(models.Model):
         budget_control_key = self.env.company.budget_control_key
         need_control = self.env.context.get("need_control")
         for budget_move in budget_moves_period:
+            if budget_move.account_id.budget_bypass:
+                continue
             if budget_period.control_all_analytic_accounts:
                 if budget_move.analytic_account_id and budget_move[budget_control_key]:
                     controls.add(
@@ -352,7 +362,7 @@ class BudgetPeriod(models.Model):
         return control, control_name
 
     @api.model
-    def _get_kpi_by_control_key(self, template_lines, control):
+    def _get_kpi_by_control_key(self, template_lines, control, budget_period=None):
         """
         By default, control key is account_id as it can be used to get KPI
         In future, this can be other key, i.e., activity_id based on installed module
@@ -365,6 +375,8 @@ class BudgetPeriod(models.Model):
         # Invalid Template Lines
         control, control_name = self._get_control_key_obj(control_key, control_id)
         if not template_line:
+            if budget_period and budget_period.unmatched_account_policy == "skip":
+                return self.env["budget.template.line"]
             raise UserError(
                 self.env._(
                     f"Chosen {control_name} {control.display_name} is not valid "
@@ -434,6 +446,11 @@ class BudgetPeriod(models.Model):
                 template_lines = self._get_filter_template_line(
                     all_template_lines, control
                 )
+                if (
+                    not template_lines
+                    and budget_period.unmatched_account_policy == "skip"
+                ):
+                    continue
             # Get the available budget for the specified analytic account and KPI(s)
             query_data = self.with_context(
                 control_level=budget_period.control_level

--- a/budget_control/tests/test_budget_control.py
+++ b/budget_control/tests/test_budget_control.py
@@ -567,3 +567,44 @@ class TestBudgetControl(get_budget_common_class()):
 
         budget_commit_forward.action_draft()
         self.assertEqual(budget_commit_forward.state, "draft")
+
+    @freeze_time("2001-02-01")
+    def test_19_unmatched_account_bypass_and_policy(self):
+        """
+        account_kpiX is not in template. Test two bypass mechanisms:
+        1. budget_bypass flag on account.account > always skip check
+        2. unmatched_account_policy = 'skip' on budget.period > pass through
+        Default policy 'error' still blocks.
+        """
+        self.budget_period.control_budget = True
+        self.budget_period.control_level = "analytic_kpi"
+        self.budget_control.action_submit()
+        self.budget_control.action_done()
+
+        analytic_distribution = {self.costcenter1.id: 100}
+
+        # Baseline: default policy 'error' + no bypass > must raise
+        self.assertEqual(self.budget_period.unmatched_account_policy, "error")
+        bill = self._create_simple_bill(analytic_distribution, self.account_kpiX, 100)
+        with self.assertRaisesRegex(UserError, "is not valid in template"):
+            bill.action_post()
+
+        # account.budget_bypass = True > skip regardless of policy
+        self.account_kpiX.budget_bypass = True
+        bill_bypass = self._create_simple_bill(
+            analytic_distribution, self.account_kpiX, 100
+        )
+        bill_bypass.action_post()
+        self.assertEqual(bill_bypass.state, "posted")
+        self.assertTrue(bill_bypass.budget_move_ids)
+        self.assertFalse(bill_bypass.budget_move_ids.mapped("template_line_id"))
+
+        # Reset bypass, switch period policy to 'skip' > also passes through
+        self.account_kpiX.budget_bypass = False
+        self.budget_period.unmatched_account_policy = "skip"
+        bill_skip = self._create_simple_bill(
+            analytic_distribution, self.account_kpiX, 100
+        )
+        bill_skip.action_post()
+        self.assertEqual(bill_skip.state, "posted")
+        self.assertTrue(bill_skip.budget_move_ids)

--- a/budget_control/views/account_account_view.xml
+++ b/budget_control/views/account_account_view.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="view_account_account_form_budget" model="ir.ui.view">
+        <field name="name">account.account.form.budget</field>
+        <field name="model">account.account</field>
+        <field name="inherit_id" ref="account.view_account_form" />
+        <field name="arch" type="xml">
+            <field name="deprecated" position="after">
+                <field name="budget_bypass" />
+            </field>
+        </field>
+    </record>
+</odoo>

--- a/budget_control/views/budget_period_view.xml
+++ b/budget_control/views/budget_period_view.xml
@@ -57,6 +57,7 @@
                                 invisible="control_all_analytic_accounts"
                             />
                             <field name="control_level" />
+                            <field name="unmatched_account_policy" />
                         </group>
                     </group>
                     <!-- <notebook>


### PR DESCRIPTION
What's New?
1. Add `Bypass Budget Control` on Chart of Account. When checked, it means this account will skip budget and not need to add it in budget template
<img width="1664" height="771" alt="selection_233" src="https://github.com/user-attachments/assets/ea95f093-5d7a-4902-a5de-9d4cf1136d5d" />
2. Add `Unmatched Account Policy` on Budget Period. For check account not in template will bypass or block
<img width="1663" height="752" alt="selection_234" src="https://github.com/user-attachments/assets/f75206d4-e1fd-4e9e-8446-a9d40b078f18" />
