### PR TITLE
[15.0][FIX] budget_control: report nowrap pivot

### DIFF
--- a/budget_control/__manifest__.py
+++ b/budget_control/__manifest__.py
@@ -47,6 +47,9 @@
     ],
     "demo": ["demo/budget_template_demo.xml"],
     "assets": {
+        "web.assets_backend": [
+            "budget_control/static/src/scss/pivot_view.scss",
+        ],
         "web.assets_qweb": [
             "budget_control/static/src/xml/budget_popover.xml",
         ],

--- a/budget_control/static/src/scss/pivot_view.scss
+++ b/budget_control/static/src/scss/pivot_view.scss
@@ -1,0 +1,16 @@
+// Override core pivot styles: allow header / value cells to wrap and break long words
+.o_pivot {
+    .o_pivot_cell_value {
+        white-space: pre-wrap;
+    }
+
+    table {
+        .o_pivot_measure_row,
+        .o_pivot_origin_row,
+        .o_pivot_header_cell,
+        .o_pivot_header_cell_closed,
+        .o_pivot_header_cell_opened {
+            white-space: pre-wrap;
+        }
+    }
+}

--- a/budget_control_queue/models/budget_commit_forward.py
+++ b/budget_control_queue/models/budget_commit_forward.py
@@ -112,7 +112,7 @@ class BudgetCommitForward(models.Model):
     def _action_cancel(self):
         """Use queue job will split function into multiple jobs"""
         if not self.use_queue_job:
-            return super().action_cancel()
+            return super()._action_cancel()
 
         ICP = self.env["ir.config_parameter"]
         chunk_size_carry_forward_cancel = (


### PR DESCRIPTION
Standard pivot use `white-space: nowrap;`
but when we have long name analytic, it will show long name without new line
<img width="1414" height="384" alt="Screenshot 2026-06-04 182542" src="https://github.com/user-attachments/assets/f9b008f4-be67-4e8a-baa7-c0445c1d6f1f" />


After fixed
<img width="1432" height="449" alt="Screenshot 2026-06-04 183449" src="https://github.com/user-attachments/assets/e06d7b7d-6a09-41b6-b7aa-0f01061c907f" />
