### PR TITLE
[18.0][FIX] budget_control: pivot new class o_budget_pivot

### DIFF
--- a/budget_control/__manifest__.py
+++ b/budget_control/__manifest__.py
@@ -3,7 +3,7 @@
 
 {
     "name": "Budget Control",
-    "version": "18.0.1.6.1",
+    "version": "18.0.1.7.0",
     "category": "Accounting",
     "license": "AGPL-3",
     "author": "Ecosoft, Odoo Community Association (OCA)",
@@ -59,6 +59,7 @@
     "assets": {
         "web.assets_backend": [
             "budget_control/static/src/xml/budget_popover.xml",
+            "budget_control/static/src/scss/pivot_wrap.scss",
         ],
     },
     "installable": True,

--- a/budget_control/report/budget_monitor_report_view.xml
+++ b/budget_control/report/budget_monitor_report_view.xml
@@ -20,7 +20,7 @@
         <field name="name">budget.monitor.report.pivot</field>
         <field name="model">budget.monitor.report</field>
         <field name="arch" type="xml">
-            <pivot string="Budget Monitoring">
+            <pivot string="Budget Monitoring" class="o_budget_pivot">
                 <field name="analytic_account_id" type="row" />
                 <field name="amount_type" type="col" />
                 <field name="amount" type="measure" />

--- a/budget_control/report/budget_move_views.xml
+++ b/budget_control/report/budget_move_views.xml
@@ -22,7 +22,7 @@
         <field name="name">account_budget_move.pivot</field>
         <field name="model">account.budget.move</field>
         <field name="arch" type="xml">
-            <pivot string="Actual Budget Commitment">
+            <pivot string="Actual Budget Commitment" class="o_budget_pivot">
                 <field name="reference" type="row" />
                 <field name="analytic_account_id" type="col" />
                 <field name="amount_currency" type="measure" />

--- a/budget_control/static/src/scss/pivot_wrap.scss
+++ b/budget_control/static/src/scss/pivot_wrap.scss
@@ -1,0 +1,14 @@
+// Override pivot view header text wrapping
+// Target only pivot views with .o_budget_pivot class to avoid affecting other pivot views.
+
+.o_budget_pivot {
+    .o_pivot table {
+        th.o_pivot_header_cell_closed,
+        th.o_pivot_header_cell_opened,
+        th.o_pivot_measure_row,
+        th.o_pivot_origin_row {
+            white-space: normal !important;
+            word-break: break-word;
+        }
+    }
+}


### PR DESCRIPTION
Same issue: https://github.com/ecosoft-odoo/budgeting/pull/563

but in v18, we add new class `o_budget_pivot` for budget only