### PR TITLE
[18.0][FIX] budget_control_expense & advance_clearing: commit budget

### DIFF
--- a/budget_control_advance_clearing/models/hr_expense.py
+++ b/budget_control_advance_clearing/models/hr_expense.py
@@ -314,3 +314,21 @@ class HRExpense(models.Model):
                     [("clearing_id", "=", clearing.id)]
                 ).unlink()
         return budget_moves
+
+    def _get_move_line_dst(
+        self,
+        move_line_name,
+        partner_id,
+        total_amount,
+        total_amount_currency,
+        account_advance,
+    ):
+        ml_dst_dict = super()._get_move_line_dst(
+            move_line_name,
+            partner_id,
+            total_amount,
+            total_amount_currency,
+            account_advance,
+        )
+        ml_dst_dict["not_affect_budget"] = True
+        return ml_dst_dict

--- a/budget_control_expense/models/account_move_line.py
+++ b/budget_control_expense/models/account_move_line.py
@@ -29,7 +29,8 @@ class AccountMoveLine(models.Model):
         Expense = self.env["hr.expense"]
         AnalyticAccount = self.env["account.analytic.account"]
 
-        for ml in self:
+        lines = self.filtered(lambda line: not line.not_affect_budget)
+        for ml in lines:
             move = ml.move_id
             # Expense created journal entry with vendor bill or not expense
             if self._condition_skip_uncommit_expense(move):


### PR DESCRIPTION
when move clearing send analytic distribution, budget will commit wrong.
This PR fixed commit EX, Actual following not_affect_budget flag

https://github.com/OCA/hr-expense/pull/368