### PR TITLE
[18.0][FIX] budget_control_expense: add not_affect_budget when install hr_expense_petty_cash

### DIFF
--- a/budget_control_expense/models/hr_expense.py
+++ b/budget_control_expense/models/hr_expense.py
@@ -125,3 +125,9 @@ class HRExpense(models.Model):
         if self._name == "hr.expense":
             return self.env.company.budget_include_tax_expense
         return super()._get_included_tax()
+
+    def _get_petty_cash_move_line_dest_vals(self, move_line_name, partner):
+        """For case install `hr_expense_petty_cash` only"""
+        vals = super()._get_petty_cash_move_line_dest_vals(move_line_name, partner)
+        vals["not_affect_budget"] = True
+        return vals


### PR DESCRIPTION
TODO:
- [x] https://github.com/OCA/hr-expense/pull/371