### PR TITLE
[18.0][FIX] budget_control_tier_validation: allow editable when reset after approved

### DIFF
--- a/budget_control_tier_validation/models/budget_control.py
+++ b/budget_control_tier_validation/models/budget_control.py
@@ -11,3 +11,11 @@ class BudgetControl(models.Model):
     _state_to = ["done"]
 
     _tier_validation_manual_config = False
+
+    def _allow_to_remove_reviews(self, values):
+        # Budget control uses "submit" as _state_from, so going back to
+        # "draft" (e.g., reset to draft) is not covered by the default rule.
+        # Extend it so reviews are cleared when the document is reset to draft.
+        if values.get(self._state_field) == "draft":
+            return True
+        return super()._allow_to_remove_reviews(values)


### PR DESCRIPTION
Step to reproduce:
1. Create budget > request validation
2. Approved > Reset to draft
3. Document can't editable