### PR TITLE
[18.0][PERF] budget_control and purchase_request: unlink bulk

### DIFF
--- a/budget_control/models/account_move_line.py
+++ b/budget_control/models/account_move_line.py
@@ -50,6 +50,9 @@ class AccountMoveLine(models.Model):
     def recompute_budget_move(self):
         return self.recompute_budget_move_batch()
 
+    def _can_batch_budget_precommit(self):
+        return True
+
     def _init_docline_budget_vals(self, budget_vals, analytic_id):
         self.ensure_one()
         if self.move_id.move_type == "entry":

--- a/budget_control/models/base_budget_move.py
+++ b/budget_control/models/base_budget_move.py
@@ -453,7 +453,7 @@ class BudgetDoclineMixin(models.AbstractModel):
         return budget_move
 
     @api.model
-    def _update_template_line_batch(self, budget_moves):
+    def _update_template_line_batch(self, budget_moves, period_dates=None):
         """Assign template/KPI once per period and budget control key.
 
         The single-record path resolves the same budget period and template line
@@ -461,10 +461,14 @@ class BudgetDoclineMixin(models.AbstractModel):
         same searches hundreds of times.  Grouping the newly-created moves keeps
         the result identical while reducing the database work to one resolution
         and one write per distinct group.
+
+        ``period_dates`` allows callers to preserve the single-record behavior
+        when the period lookup date differs from the budget move date.
         """
         if not budget_moves:
             return budget_moves
 
+        period_dates = period_dates or {}
         BudgetPeriod = self.env["budget.period"]
         control_key = self.env.company.budget_control_key
         periods_by_date = {}
@@ -474,11 +478,12 @@ class BudgetDoclineMixin(models.AbstractModel):
         for move in budget_moves:
             if move.account_id.budget_bypass or not move[control_key]:
                 continue
-            if move.date not in periods_by_date:
-                periods_by_date[move.date] = BudgetPeriod._get_eligible_budget_period(
-                    move.date
+            period_date = period_dates.get(move.id, move.date)
+            if period_date not in periods_by_date:
+                periods_by_date[period_date] = BudgetPeriod._get_eligible_budget_period(
+                    period_date
                 )
-            period = periods_by_date[move.date]
+            period = periods_by_date[period_date]
             if not period:
                 continue
             key = (period.id, move[control_key].id)
@@ -518,13 +523,13 @@ class BudgetDoclineMixin(models.AbstractModel):
         BudgetPeriod = self.env["budget.period"]
         for docline in self:
             if not docline.fwd_analytic_distribution or not docline.fwd_date_commit:
-                return
+                continue
             if (
                 docline[self._budget_analytic_field]
                 == docline.fwd_analytic_distribution
                 and docline.date_commit == docline.fwd_date_commit
             ):  # no forward to same date
-                return
+                continue
             domain_fwd_line = self._get_domain_fwd_line(docline)
             fwd_lines = ForwardLine.search(domain_fwd_line)
             # NOTE: this function will support commit forward more than 1 time
@@ -753,6 +758,42 @@ class BudgetDoclineMixin(models.AbstractModel):
             return self.env[doclines._budget_model()]
         budget_moves = self.env[doclines._budget_model()].create(budget_vals)
         return doclines._update_template_line_batch(budget_moves)
+
+    def _can_batch_budget_precommit(self):
+        """Opt in only when batch precommit matches commit_budget() semantics."""
+        return False
+
+    def _create_precommit_budget_moves_batch(self):
+        """Create temporary forced commitments and preserve per-line dates."""
+        doclines = self.sudo()
+        reset_date_lines = doclines.filtered(lambda line: not line.date_commit)
+        force_doclines = doclines.with_context(force_commit=True)
+
+        for line in force_doclines:
+            if line._check_required_analytic():
+                raise UserError(self.env._("Please fill analytic account."))
+
+        force_doclines.prepare_commit_batch()
+        to_commit = force_doclines.filtered("can_commit")
+        not_to_commit = force_doclines - to_commit
+        if not_to_commit:
+            not_to_commit.mapped(not_to_commit._budget_field()).unlink()
+
+        budget_vals = []
+        move_period_dates = []
+        for line in to_commit:
+            line_vals = line._prepare_commit_vals()
+            budget_vals.extend(line_vals)
+            move_period_dates.extend([line.date_commit] * len(line_vals))
+        if not budget_vals:
+            return force_doclines.env[force_doclines._budget_model()], reset_date_lines
+
+        budget_moves = force_doclines.env[force_doclines._budget_model()].create(
+            budget_vals
+        )
+        period_dates = dict(zip(budget_moves.ids, move_period_dates, strict=False))
+        to_commit._update_template_line_batch(budget_moves, period_dates=period_dates)
+        return budget_moves, reset_date_lines
 
     def _required_fields_to_commit(self):
         return [self._budget_analytic_field]

--- a/budget_control/models/budget_period.py
+++ b/budget_control/models/budget_period.py
@@ -1,7 +1,7 @@
 # Copyright 2020 Ecosoft Co., Ltd. (http://ecosoft.co.th)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import _, api, fields, models
+from odoo import api, fields, models
 from odoo.exceptions import UserError, ValidationError
 from odoo.tools import SQL, float_compare, format_amount
 
@@ -242,27 +242,33 @@ class BudgetPeriod(models.Model):
             budget_moves_uncommit = doclines.with_context(
                 force_commit=True
             ).uncommit_purchase_budget()
-        # Commit budget
-        budget_moves = []
-        vals_date_commit = []
-        for line in doclines:
-            if not line.date_commit:
-                vals_date_commit.append(line.id)
-            budget_move = line.with_context(force_commit=True).commit_budget()
-            if budget_move:
-                budget_moves.append(budget_move)
-        # Update database, so we can check budget with query
-        if budget_move:
-            budget_move.flush_model()
+        # Batch only models that explicitly guarantee equivalence with their
+        # commit_budget() behavior. Other models keep the original line loop.
+        if doclines._can_batch_budget_precommit():
+            budget_moves, reset_date_lines = (
+                doclines._create_precommit_budget_moves_batch()
+            )
+            budget_move_groups = [budget_moves]
+        else:
+            budget_move_groups = []
+            reset_date_lines = doclines.filtered(lambda line: not line.date_commit)
+            for line in doclines:
+                budget_move = line.with_context(force_commit=True).commit_budget()
+                if budget_move:
+                    budget_move_groups.append(budget_move)
+        # Update database, so we can check budget with query.
+        flushed_models = set()
+        for budget_moves in budget_move_groups:
+            if budget_moves and budget_moves._name not in flushed_models:
+                budget_moves.flush_model()
+                flushed_models.add(budget_moves._name)
         # Check Budget
         self.env["budget.period"].check_budget(doclines, doc_type=doc_type)
         # Remove commits
-        for budget_move in budget_moves:
-            budget_move.unlink()
+        for budget_moves in budget_move_groups:
+            budget_moves.unlink()
         # Delete date commit from system create auto only
-        doclines.filtered(
-            lambda line, vals_date_commit=vals_date_commit: line.id in vals_date_commit
-        ).write({"date_commit": False})
+        reset_date_lines.write({"date_commit": False})
         # Remove uncommit budget
         if budget_moves_uncommit:
             budget_moves_uncommit.unlink()
@@ -424,7 +430,10 @@ class BudgetPeriod(models.Model):
         return self.env["budget.monitor.report"]
 
     def _get_budget_avaiable(self, analytic_id, template_lines):
-        self.env.flush_all()
+        # Callers that batch many queries can set env.context['skip_budget_flush']
+        # after flushing once themselves, avoiding a flush_all() per control.
+        if not self.env.context.get("skip_budget_flush"):
+            self.env.flush_all()
         self.env.cr.execute(
             SQL(
                 f"""
@@ -453,6 +462,12 @@ class BudgetPeriod(models.Model):
         company = self.env.user.company_id
         doc_currency = self.env.context.get("doc_currency")
         date_commit = self.env.context.get("date_commit")
+        # Flush once for all controls. Budget moves are not written while this
+        # loop runs (it only reads and raises/returns), so a single flush before
+        # the loop is enough and avoids repeating the expensive flush_all() per
+        # control when checking many analytics/KPIs.
+        self.env.flush_all()
+        self = self.with_context(skip_budget_flush=True)
         for control in controls:
             analytic_id = control["analytic_id"]
             # Get the KPI(s) to check the budget,
@@ -476,7 +491,7 @@ class BudgetPeriod(models.Model):
             )
             if budget_period.control_level == "analytic_kpi" and not data_budget:
                 raise UserError(
-                    _("Chosen KPI %s is not valid for budgeting")
+                    self.env._("Chosen KPI %s is not valid for budgeting")
                     % template_lines.display_name
                 )
             balance = sum(
@@ -497,7 +512,9 @@ class BudgetPeriod(models.Model):
                 if budget_period.control_level == "analytic_kpi":
                     analytic_name = f"{template_lines.display_name} & {analytic_name}"
                 warnings.append(
-                    _("{analytic_name}, will result in {formatted_balance}").format(
+                    self.env._(
+                        "{analytic_name}, will result in {formatted_balance}"
+                    ).format(
                         analytic_name=analytic_name, formatted_balance=fomatted_balance
                     )
                 )

--- a/budget_control_purchase/models/purchase.py
+++ b/budget_control_purchase/models/purchase.py
@@ -96,10 +96,13 @@ class PurchaseOrderLine(models.Model):
 
     def recompute_budget_move(self):
         self.recompute_budget_move_batch()
-        for purchase_line in self:
+        for purchase_line in self.filtered("fwd_analytic_distribution"):
             # credit will not over debit (auto adjust)
             purchase_line.forward_commit()
         self.mapped("invoice_lines").uncommit_purchase_budget()
+
+    def _can_batch_budget_precommit(self):
+        return True
 
     def _get_po_line_account(self):
         fpos = self.order_id.fiscal_position_id

--- a/budget_control_purchase_request/models/purchase.py
+++ b/budget_control_purchase_request/models/purchase.py
@@ -2,6 +2,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo import models
+from odoo.exceptions import UserError
 
 
 class PurchaseOrder(models.Model):
@@ -19,22 +20,117 @@ class PurchaseOrderLine(models.Model):
     _inherit = "purchase.order.line"
 
     def uncommit_purchase_request_budget(self):
-        """For purchase in valid state, do uncommit for related PR."""
-        budget_moves = self.env["purchase.request.budget.move"]
-        for po_line in self:
-            po_state = po_line.order_id.state
-            if self.env.context.get("force_commit") or po_state in ("purchase", "done"):
+        """For purchase in valid state, do uncommit for related PR.
+
+        Batched to avoid one create / search-unlink per purchase line, while
+        keeping the result identical to the former per-line loop. For each
+        purchase line, that loop did:
+
+            if force_commit or po_state in ("purchase", "done"):
                 for pr_line in po_line.purchase_request_lines.filtered("amount_commit"):
-                    move = pr_line.commit_budget(
+                    pr_line.commit_budget(
                         reverse=True,
                         analytic_account_id=pr_line.fwd_analytic_distribution or False,
                         purchase_line_id=po_line.id,
                         date=po_line.date_commit,
                     )
-                    if move:
-                        budget_moves |= move
-            else:  # Cancel or draft, not commitment line
-                self.env["purchase.request.budget.move"].search(
-                    [("purchase_line_id", "=", po_line.id)]
-                ).unlink()
+            else:  # cancel/draft
+                search([("purchase_line_id", "=", po_line.id)]).unlink()
+
+        So each (po_line, pr_line) pair produces its own reverse move (a PR
+        line shared by several PO lines yields one reverse move per PO line),
+        and cancel/draft purchase lines delete their reverse moves in one go.
+        """
+        BudgetMove = self.env["purchase.request.budget.move"]
+        PRLine = self.env["purchase.request.line"]
+        force_commit = self.env.context.get("force_commit")
+
+        # cancel/draft purchase lines: delete all their reverse moves in one query
+        unlink_po_lines = self.filtered(
+            lambda line: not force_commit
+            and line.order_id.state not in ("purchase", "done")
+        )
+        if unlink_po_lines:
+            BudgetMove.search(
+                [("purchase_line_id", "in", unlink_po_lines.ids)]
+            ).unlink()
+
+        # purchase/done purchase lines: build reverse commits for related PR lines
+        commit_po_lines = self - unlink_po_lines
+        if not commit_po_lines:
+            return BudgetMove
+
+        # Pairs in the same order the nested loop produced them: outer = po_line,
+        # inner = pr_line (only those with amount_commit).
+        pairs = []
+        all_pr_line_ids = []
+        seen_pr_line_ids = set()
+        for po_line in commit_po_lines:
+            for pr_line in po_line.purchase_request_lines.filtered("amount_commit"):
+                pairs.append(
+                    (
+                        pr_line,
+                        {
+                            "analytic_account_id": (
+                                pr_line.fwd_analytic_distribution or False
+                            ),
+                            "purchase_line_id": po_line.id,
+                            "date": po_line.date_commit,
+                        },
+                    )
+                )
+                if pr_line.id not in seen_pr_line_ids:
+                    seen_pr_line_ids.add(pr_line.id)
+                    all_pr_line_ids.append(pr_line.id)
+        if not pairs:
+            return BudgetMove
+        all_pr_lines = PRLine.browse(all_pr_line_ids)
+
+        # Keep the same required-analytic validation as commit_budget().
+        for pr_line in all_pr_lines:
+            if pr_line._check_required_analytic():
+                raise UserError(self.env._("Please fill analytic account."))
+
+        # Set date_commit once for all eligible PR lines (prepare_commit path).
+        all_pr_lines.prepare_commit_batch()
+
+        # commit_budget() only creates a reverse move when can_commit AND a valid
+        # commit state; otherwise it deletes the line's existing moves. Mirror
+        # that here so the result matches the per-line calls.
+        to_commit = all_pr_lines.filtered(
+            lambda line: line.can_commit
+            and (force_commit or line._valid_commit_state())
+        )
+        no_commit = all_pr_lines - to_commit
+        if no_commit:
+            no_commit.mapped(no_commit._budget_field()).unlink()
+
+        if not to_commit:
+            return BudgetMove
+
+        # Build the reverse commit vals for every (pr_line, po_line) pair, in the
+        # same order as the original nested loop, then create them in one batch.
+        budget_vals = []
+        to_commit_ids = set(to_commit.ids)
+        for pr_line, vals in pairs:
+            if pr_line.id not in to_commit_ids:
+                continue
+            budget_vals.extend(pr_line._prepare_commit_vals(reverse=True, **vals))
+        if not budget_vals:
+            return BudgetMove
+
+        budget_moves = BudgetMove.create(budget_vals)
+        # Template/KPI assignment is batched (grouped by period + control key)
+        # instead of one resolution per move. The former commit_budget() path
+        # resolved the period from the source PR date, not the reverse move's
+        # PO date, so preserve that behavior explicitly.
+        period_dates = {
+            move.id: move.purchase_request_line_id.date_commit for move in budget_moves
+        }
+        to_commit._update_template_line_batch(budget_moves, period_dates=period_dates)
+        # On reverse, ensure no over-return. Per-line like commit_budget(), as it
+        # may create an additional adjustment move based on the line's totals.
+        BudgetPeriod = self.env["budget.period"]
+        for pr_line in to_commit:
+            BudgetPeriod.check_over_returned_budget(pr_line)
         return budget_moves

--- a/budget_control_purchase_request/models/purchase_request.py
+++ b/budget_control_purchase_request/models/purchase_request.py
@@ -84,12 +84,13 @@ class PurchaseRequestLine(models.Model):
             rec.account_id = rec._get_pr_line_account()
 
     def recompute_budget_move(self):
-        for pr_line in self:
-            pr_line.budget_move_ids.unlink()
-            pr_line.commit_budget()
-            # credit will not over debit (auto adjust)
+        self.recompute_budget_move_batch()
+        for pr_line in self.filtered("fwd_analytic_distribution"):
             pr_line.forward_commit()
-            pr_line.purchase_lines.uncommit_purchase_request_budget()
+        self.mapped("purchase_lines").uncommit_purchase_request_budget()
+
+    def _can_batch_budget_precommit(self):
+        return True
 
     def _get_pr_line_account(self):
         account = self.product_id.product_tmpl_id.get_product_accounts()["expense"]

--- a/budget_control_purchase_request/tests/test_budget_purchase_request.py
+++ b/budget_control_purchase_request/tests/test_budget_purchase_request.py
@@ -5,7 +5,7 @@ from datetime import datetime
 
 from freezegun import freeze_time
 
-from odoo import Command
+from odoo import Command, fields
 from odoo.exceptions import UserError
 from odoo.tests import Form, tagged
 
@@ -76,6 +76,33 @@ class TestBudgetControlPurchaseRequest(get_budget_common_class()):
                     line.analytic_distribution = pr_line["analytic_distribution"]
         purchase_request = pr.save()
         return purchase_request
+
+    def _create_purchase_for_request_line(self, request_line, price_unit):
+        """Create a separate PO linked to the same purchase request line."""
+        product_uom = request_line.product_id.uom_po_id or request_line.product_uom_id
+        purchase = self.env["purchase.order"].create(
+            {
+                "partner_id": self.vendor.id,
+                "date_order": datetime.today(),
+                "order_line": [
+                    Command.create(
+                        {
+                            "name": request_line.name,
+                            "product_id": request_line.product_id.id,
+                            "product_qty": 1,
+                            "product_uom": product_uom.id,
+                            "price_unit": price_unit,
+                            "date_planned": datetime.today(),
+                            "analytic_distribution": (
+                                request_line.analytic_distribution
+                            ),
+                            "purchase_request_lines": [Command.link(request_line.id)],
+                        }
+                    )
+                ],
+            }
+        )
+        return purchase.with_context(force_date_commit=purchase.date_order)
 
     @freeze_time("2001-02-01")
     def test_01_budget_purchase_request(self):
@@ -291,3 +318,113 @@ class TestBudgetControlPurchaseRequest(get_budget_common_class()):
         self.assertAlmostEqual(self.budget_control.amount_purchase_request, 0)
         self.assertAlmostEqual(self.budget_control.amount_purchase, 0)
         self.assertAlmostEqual(self.budget_control.amount_balance, 2400.0)
+
+    @freeze_time("2001-02-01")
+    def test_04_budget_1pr_many_po(self):
+        """One PR line split across POs must not return its budget twice."""
+        self.budget_control.action_submit()
+        self.budget_control.action_done()
+        self.budget_period.control_budget = True
+        self.budget_period.purchase = True
+        self.budget_period.control_level = "analytic"
+
+        analytic_distribution = {str(self.costcenter1.id): 100}
+        purchase_request = self._create_purchase_request(
+            [
+                {
+                    "product_id": self.product1,
+                    "product_qty": 2,
+                    "estimated_cost": 2000.0,
+                    "analytic_distribution": analytic_distribution,
+                }
+            ]
+        ).with_context(force_date_commit=fields.Date.to_date("2001-02-01"))
+        purchase_request.button_to_approve()
+        purchase_request.button_approved()
+        self.assertAlmostEqual(self.budget_control.amount_purchase_request, 2000.0)
+
+        request_line = purchase_request.line_ids
+        purchase1 = self._create_purchase_for_request_line(request_line, 25.0)
+        purchase2 = self._create_purchase_for_request_line(request_line, 25.0)
+
+        purchase1.button_confirm()
+        self.assertAlmostEqual(self.budget_control.amount_purchase_request, 0.0)
+        self.assertAlmostEqual(self.budget_control.amount_purchase, 25.0)
+
+        purchase2.button_confirm()
+        self.assertAlmostEqual(self.budget_control.amount_purchase_request, 0.0)
+        self.assertAlmostEqual(self.budget_control.amount_purchase, 50.0)
+        reverse_moves = purchase_request.budget_move_ids.filtered("purchase_line_id")
+        adjustment_moves = purchase_request.budget_move_ids.filtered("adj_commit")
+        self.assertEqual(len(reverse_moves), 2)
+        self.assertAlmostEqual(sum(reverse_moves.mapped("credit")), 4000.0)
+        self.assertEqual(len(adjustment_moves), 1)
+        self.assertAlmostEqual(sum(adjustment_moves.mapped("debit")), 2000.0)
+
+        purchase2.button_cancel()
+        self.assertAlmostEqual(self.budget_control.amount_purchase_request, 0.0)
+        self.assertAlmostEqual(self.budget_control.amount_purchase, 25.0)
+
+        purchase1.button_cancel()
+        self.assertAlmostEqual(self.budget_control.amount_purchase_request, 2000.0)
+        self.assertAlmostEqual(self.budget_control.amount_purchase, 0.0)
+
+    @freeze_time("2001-02-01")
+    def test_05_precommit_batch_preserves_line_dates(self):
+        """Precommit batches different dates and only clears generated dates."""
+        self.budget_control.action_submit()
+        self.budget_control.action_done()
+        self.budget_period.control_budget = True
+        self.budget_period.purchase_request = True
+        self.budget_period.control_level = "analytic"
+
+        analytic_distribution = {str(self.costcenter1.id): 100}
+        purchase_request = self._create_purchase_request(
+            [
+                {
+                    "product_id": self.product1,
+                    "product_qty": 1,
+                    "estimated_cost": 100.0,
+                    "analytic_distribution": analytic_distribution,
+                },
+                {
+                    "product_id": self.product2,
+                    "product_qty": 1,
+                    "estimated_cost": 200.0,
+                    "analytic_distribution": analytic_distribution,
+                },
+                {
+                    "product_id": self.product1,
+                    "product_qty": 1,
+                    "estimated_cost": 300.0,
+                    "analytic_distribution": analytic_distribution,
+                },
+            ]
+        )
+        lines = purchase_request.line_ids.sorted("id")
+        manual_date1 = fields.Date.to_date("2001-02-10")
+        manual_date2 = fields.Date.to_date("2001-03-20")
+        lines[0].date_commit = manual_date1
+        lines[1].date_commit = manual_date2
+        self.assertFalse(lines[2].date_commit)
+
+        budget_moves, reset_date_lines = lines._create_precommit_budget_moves_batch()
+        moves_by_line = {
+            move.purchase_request_line_id.id: move for move in budget_moves
+        }
+        self.assertEqual(moves_by_line[lines[0].id].date, manual_date1)
+        self.assertEqual(moves_by_line[lines[1].id].date, manual_date2)
+        self.assertEqual(
+            moves_by_line[lines[2].id].date,
+            fields.Date.to_date(purchase_request.write_date),
+        )
+        self.assertEqual(reset_date_lines, lines[2])
+        budget_moves.unlink()
+        reset_date_lines.write({"date_commit": False})
+
+        purchase_request.button_to_approve()
+        self.assertEqual(purchase_request.state, "to_approve")
+        self.assertFalse(purchase_request.budget_move_ids)
+        self.assertEqual(lines[0].date_commit, manual_date1)
+        self.assertEqual(lines[1].date_commit, manual_date2)
+        self.assertFalse(lines[2].date_commit)


### PR DESCRIPTION
This PR improved performance PR / PO Budgeting

### Benchmark:

| Case | Time Before | Time After |
|---------------|-------------|------------|
| PR Confirm 100 Lines     | 2.3s       | 0.4s        |
| PR Reset 100 Lines     | 5.9s       | 0.6s        |
| PO Confirm (from PR) 100 Lines     | 21s         | 2.5s   |
| PR Confirm 500 Lines     | 9s       | 1.8s        |
| PR Reset 500 Lines     | 22s       | 2.6s        |
| PO Confirm (from PR) 500 Lines     | 88.4s         | 12.1s   |