### PR TITLE
[18.0][PERF] budget_control_advance_expense: batch created

### DIFF
--- a/budget_control_advance_clearing/models/hr_expense.py
+++ b/budget_control_advance_clearing/models/hr_expense.py
@@ -3,6 +3,7 @@
 
 from odoo import api, fields, models
 from odoo.exceptions import UserError
+from odoo.tools import float_compare
 
 
 class HRExpenseSheet(models.Model):
@@ -104,12 +105,10 @@ class HRExpense(models.Model):
 
     def _get_recompute_advances(self):
         AnalyticAccount = self.env["account.analytic.account"]
-        # date_commit return list, so we check in list again
-        advance_date_commit = (
-            self.env.context.get("force_date_commit", False)
-            or self.mapped("date_commit")[:-1]
-            or False
-        )
+        # The batch helper preserves date_commit per expense line.  A mapped
+        # list cannot represent different dates in one context and is not a
+        # valid value for fields.Date.to_date().
+        advance_date_commit = self.env.context.get("force_date_commit", False)
 
         # Commit Advance
         res = super(
@@ -234,21 +233,175 @@ class HRExpense(models.Model):
             )
         return super().commit_budget(reverse=reverse, **vals)
 
-    def uncommit_advance_budget(self):
-        """For clearing in valid state,
-        do uncommit for related Advance sorted by date commit."""
-        budget_moves = self.env["advance.budget.move"]
-        AnalyticAccount = self.env["account.analytic.account"]
-        # Sorted clearing by date_commit first. for case clearing > advance
-        # it should uncommit clearing that approved first
+    def _get_sorted_clearings(self):
+        """Keep the allocation order used by the former per-line implementation."""
         clearing_approved = self.filtered("date_commit")
         clearing_not_approved = self - clearing_approved
-        clearing_sorted = (
+        return (
             clearing_approved.sorted(key=lambda clearing: clearing.date_commit)
             + clearing_not_approved
         )
+
+    def _get_clearing_advance_data(self, clearing, cache, remaining):
+        """Cache invariant advance data and validate the analytic distribution."""
+        advance_sheet = clearing.sheet_id.advance_sheet_id
+        if advance_sheet.id not in cache:
+            advance_lines = advance_sheet.expense_line_ids
+            advances = advance_lines.filtered("amount_commit")
+            analytic_ids = set()
+            for advance in advance_lines:
+                analytic_ids.update(advance.fwd_analytic_distribution or {})
+                analytic_ids.update(advance.analytic_distribution or {})
+            cache[advance_sheet.id] = (advances, analytic_ids)
+            for advance in advances:
+                for analytic_id, amount in (advance.amount_commit or {}).items():
+                    remaining[(advance.id, analytic_id)] = amount
+
+        advances, advance_analytic_ids = cache[advance_sheet.id]
+        if any(
+            analytic_id not in advance_analytic_ids
+            for analytic_id in clearing.analytic_distribution
+        ):
+            raise UserError(
+                self.env._(
+                    "Analytic distribution mismatch. "
+                    "Please align with the original advance."
+                )
+            )
+        return advances
+
+    def _prepare_advance_for_batch(self, advance, prepared_advances):
+        if advance.id not in prepared_advances:
+            batch_advance = advance.with_context(
+                alt_budget_move_model="advance.budget.move",
+                alt_budget_move_field="advance_budget_move_ids",
+            )
+            batch_advance.prepare_commit()
+            can_create = batch_advance.can_commit and (
+                self.env.context.get("force_commit")
+                or batch_advance._valid_commit_state()
+            )
+            prepared_advances[advance.id] = batch_advance if can_create else False
+        return prepared_advances[advance.id]
+
+    def _prepare_advance_uncommit_entries(self):
+        AnalyticAccount = self.env["account.analytic.account"]
         config_budget_include_tax = self.env.company.budget_include_tax
-        for clearing in clearing_sorted:
+        force_commit = self.env.context.get("force_commit")
+        advance_cache = {}
+        remaining = {}
+        prepared_advances = {}
+        entries = []
+        draft_clearing_ids = []
+
+        for clearing in self._get_sorted_clearings():
+            if not force_commit and clearing.sheet_id.state not in (
+                "approve",
+                "post",
+                "done",
+            ):
+                draft_clearing_ids.append(clearing.id)
+                continue
+
+            advances = self._get_clearing_advance_data(
+                clearing, advance_cache, remaining
+            )
+            if not advances:
+                continue
+            origin_amount = (
+                clearing.total_amount_currency
+                if config_budget_include_tax
+                else clearing.untaxed_amount_currency
+            )
+            for analytic_id, percent in clearing.analytic_distribution.items():
+                clearing_amount = origin_amount * (percent / 100)
+                analytic = AnalyticAccount.browse(int(analytic_id))
+                for advance in advances:
+                    remaining_key = (advance.id, str(analytic_id))
+                    available = remaining.get(remaining_key, 0.0)
+                    if not available:
+                        continue
+                    amount = min(available, clearing_amount)
+                    remaining[remaining_key] -= amount
+                    clearing_amount -= amount
+                    batch_advance = self._prepare_advance_for_batch(
+                        advance, prepared_advances
+                    )
+                    if not batch_advance:
+                        return False, draft_clearing_ids
+                    commit_kwargs = {
+                        "clearing_id": clearing.id,
+                        "amount_currency": amount,
+                        "analytic_account_id": analytic,
+                        "date": clearing.date_commit,
+                    }
+                    entries.append(
+                        (
+                            batch_advance,
+                            commit_kwargs,
+                            batch_advance._prepare_commit_vals(
+                                reverse=True, **commit_kwargs
+                            ),
+                        )
+                    )
+                    if clearing_amount <= 0:
+                        break
+        return entries, draft_clearing_ids
+
+    def _entries_can_create_in_batch(self, entries):
+        entries_by_sheet = {}
+        for entry in entries:
+            entries_by_sheet.setdefault(entry[0].sheet_id.id, []).append(entry)
+        for sheet_entries in entries_by_sheet.values():
+            existing_moves = sheet_entries[0][0].sheet_id.advance_budget_move_ids
+            projected_debit = sum(existing_moves.mapped("debit"))
+            projected_credit = sum(existing_moves.mapped("credit"))
+            for _advance, _commit_kwargs, vals_list in sheet_entries:
+                projected_debit += sum(vals["debit"] for vals in vals_list)
+                projected_credit += sum(vals["credit"] for vals in vals_list)
+                if float_compare(projected_credit, projected_debit, 2) == 1:
+                    return False
+        return True
+
+    def _create_advance_uncommit_entries(self, entries):
+        budget_moves = self.env["advance.budget.move"]
+        if not entries:
+            return budget_moves
+        if not self._entries_can_create_in_batch(entries):
+            for advance, commit_kwargs, _vals in entries:
+                budget_moves |= advance.commit_budget(reverse=True, **commit_kwargs)
+            return budget_moves
+
+        budget_vals = []
+        move_period_dates = []
+        for advance, _commit_kwargs, vals_list in entries:
+            budget_vals.extend(vals_list)
+            move_period_dates.extend([advance.date_commit] * len(vals_list))
+        budget_moves = budget_moves.create(budget_vals)
+        period_dates = dict(zip(budget_moves.ids, move_period_dates, strict=False))
+        self._update_template_line_batch(budget_moves, period_dates=period_dates)
+        return budget_moves
+
+    def uncommit_advance_budget(self):
+        """Return clearing amounts in legacy order, then create moves in bulk."""
+        entries, draft_clearing_ids = self._prepare_advance_uncommit_entries()
+        if entries is False:
+            # This can only happen for an invalid advance state.  Preserve the
+            # old behavior by letting commit_budget() handle the entries one by one.
+            return self._uncommit_advance_budget_sequential()
+        budget_moves = self._create_advance_uncommit_entries(entries)
+        if draft_clearing_ids:
+            self.env["advance.budget.move"].search(
+                [("clearing_id", "in", draft_clearing_ids)]
+            ).unlink()
+        return budget_moves
+
+    def _uncommit_advance_budget_sequential(self):
+        """Compatibility path for an unexpected invalid advance state."""
+        budget_moves = self.env["advance.budget.move"]
+        AnalyticAccount = self.env["account.analytic.account"]
+        config_budget_include_tax = self.env.company.budget_include_tax
+        for clearing in self._get_sorted_clearings():
             cl_state = clearing.sheet_id.state
             if self.env.context.get("force_commit") or cl_state in (
                 "approve",
@@ -309,7 +462,6 @@ class HRExpense(models.Model):
                         if clearing_amount <= 0:
                             break
             else:
-                # Cancel or draft, not commitment line
                 self.env["advance.budget.move"].search(
                     [("clearing_id", "=", clearing.id)]
                 ).unlink()

--- a/budget_control_advance_clearing/tests/test_budget_advance.py
+++ b/budget_control_advance_clearing/tests/test_budget_advance.py
@@ -144,6 +144,7 @@ class TestBudgetControlAdvance(get_budget_common_class()):
         analytic_distribution = {str(self.costcenter1.id): 100}
         # Create advance = 100
         advance = self._create_advance_sheet(100, analytic_distribution)
+        self.assertFalse(advance.expense_line_ids._can_batch_budget_precommit())
         # (1) No budget check first
         self.budget_period.advance = False
         self.budget_period.control_level = "analytic_kpi"
@@ -404,3 +405,125 @@ class TestBudgetControlAdvance(get_budget_common_class()):
         self.assertAlmostEqual(advance.clearing_residual, 70.0)
         self.assertAlmostEqual(self.budget_control.amount_advance, 70.0)
         self.assertAlmostEqual(self.budget_control.amount_balance, 2330.0)
+
+    @freeze_time("2001-02-01")
+    def test_05_batch_clearing_matches_sequential(self):
+        """Batch allocation keeps the legacy line order and capped amount."""
+        analytic_distribution = {str(self.costcenter1.id): 100}
+        advance = self._create_advance_sheet(30, analytic_distribution)
+        date_commit = fields.Date.to_date("2001-02-01")
+        advance.expense_line_ids.with_context(
+            force_commit=True, force_date_commit=date_commit
+        ).recompute_budget_move()
+
+        clearing = self._create_clearing_sheet(
+            advance,
+            [
+                {
+                    "product_id": self.product1,
+                    "product_qty": 1,
+                    "price_unit": 1,
+                    "analytic_distribution": analytic_distribution,
+                }
+                for _index in range(50)
+            ],
+        )
+        clearings = clearing.expense_line_ids.sorted("id")
+        clearings.write({"date_commit": date_commit})
+
+        batch_moves = clearings.with_context(
+            force_commit=True
+        ).uncommit_advance_budget()
+        batch_result = [
+            (
+                move.clearing_id.id,
+                move.debit,
+                move.credit,
+                move.date,
+                move.template_line_id.id,
+            )
+            for move in batch_moves.sorted("id")
+        ]
+        self.assertEqual(batch_moves.mapped("clearing_id"), clearings[:30])
+        self.assertAlmostEqual(sum(batch_moves.mapped("credit")), 30.0)
+
+        batch_moves.unlink()
+        advance.expense_line_ids.invalidate_recordset(["amount_commit"])
+        sequential_moves = clearings.with_context(
+            force_commit=True
+        )._uncommit_advance_budget_sequential()
+        sequential_result = [
+            (
+                move.clearing_id.id,
+                move.debit,
+                move.credit,
+                move.date,
+                move.template_line_id.id,
+            )
+            for move in sequential_moves.sorted("id")
+        ]
+        self.assertEqual(batch_result, sequential_result)
+
+    @freeze_time("2001-02-01")
+    def test_06_clearing_analytic_must_match_advance(self):
+        """A clearing cannot uncommit an analytic absent from its advance."""
+        advance_distribution = {str(self.costcenter1.id): 100}
+        advance = self._create_advance_sheet(30, advance_distribution)
+        date_commit = fields.Date.to_date("2001-02-01")
+        advance.expense_line_ids.with_context(
+            force_commit=True, force_date_commit=date_commit
+        ).recompute_budget_move()
+
+        clearing_distribution = {str(self.costcenterX.id): 100}
+        clearing = self._create_clearing_sheet(
+            advance,
+            [
+                {
+                    "product_id": self.product1,
+                    "product_qty": 1,
+                    "price_unit": 10,
+                    "analytic_distribution": clearing_distribution,
+                }
+            ],
+        )
+
+        with self.assertRaisesRegex(UserError, "Analytic distribution mismatch"):
+            clearing.expense_line_ids.with_context(
+                force_commit=True
+            ).uncommit_advance_budget()
+
+    @freeze_time("2001-02-01")
+    def test_07_over_returned_entries_keep_sequential_adjustment(self):
+        """An exceptional over-return uses commit_budget's adjustment path."""
+        analytic_distribution = {str(self.costcenter1.id): 100}
+        advance_sheet = self._create_advance_sheet(30, analytic_distribution)
+        date_commit = fields.Date.to_date("2001-02-01")
+        advance = advance_sheet.expense_line_ids.with_context(
+            force_commit=True,
+            force_date_commit=date_commit,
+            alt_budget_move_model="advance.budget.move",
+            alt_budget_move_field="advance_budget_move_ids",
+        )
+        advance.recompute_budget_move()
+
+        commit_kwargs = {
+            "amount_currency": 31,
+            "analytic_account_id": self.costcenter1,
+            "date": date_commit,
+        }
+        entries = [
+            (
+                advance,
+                commit_kwargs,
+                advance._prepare_commit_vals(reverse=True, **commit_kwargs),
+            )
+        ]
+        self.assertFalse(advance._entries_can_create_in_batch(entries))
+
+        returned_moves = advance._create_advance_uncommit_entries(entries)
+
+        self.assertEqual(len(returned_moves), 1)
+        self.assertAlmostEqual(returned_moves.credit, 31.0)
+        adjustment = advance_sheet.advance_budget_move_ids.filtered("adj_commit")
+        self.assertEqual(len(adjustment), 1)
+        self.assertAlmostEqual(adjustment.debit, 1.0)

--- a/budget_control_expense/models/__init__.py
+++ b/budget_control_expense/models/__init__.py
@@ -14,4 +14,5 @@ from . import account_move_line
 
 # Expense Module
 from . import expense_budget_move
+from . import hr_expense_sheet
 from . import hr_expense

--- a/budget_control_expense/models/account_move_line.py
+++ b/budget_control_expense/models/account_move_line.py
@@ -2,6 +2,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo import models
+from odoo.tools import float_compare
 
 
 class AccountMoveLine(models.Model):
@@ -23,13 +24,11 @@ class AccountMoveLine(models.Model):
     def _condition_skip_uncommit_expense(self, move):
         return move.move_type != "in_invoice" or not move.expense_sheet_id
 
-    def uncommit_expense_budget(self):
-        """Uncommit the budget for related expenses
-        when the vendor bill is in a valid state."""
-        Expense = self.env["hr.expense"]
+    def _prepare_expense_reverse_entries(self):
         AnalyticAccount = self.env["account.analytic.account"]
-
         lines = self.filtered(lambda line: not line.not_affect_budget)
+        reverse_entries = []
+        draft_line_ids = []
         for ml in lines:
             move = ml.move_id
             # Expense created journal entry with vendor bill or not expense
@@ -46,18 +45,83 @@ class AccountMoveLine(models.Model):
                     continue
 
                 if ml.analytic_distribution:
+                    # Do the state/date preparation once per journal line.  The
+                    # former commit_budget() loop repeated this for every analytic.
+                    expense.prepare_commit()
+                    if not expense.can_commit or not (
+                        self.env.context.get("force_commit")
+                        or expense._valid_commit_state()
+                    ):
+                        continue
                     analytic_accounts = {
                         int(aid): AnalyticAccount.browse(int(aid))
                         for aid in ml.analytic_distribution
                     }
                     for analytic_id, _ in ml.analytic_distribution.items():
-                        expense.commit_budget(
-                            reverse=True,
-                            move_line_id=ml.id,
-                            date=ml.date_commit,
-                            analytic_account_id=analytic_accounts[int(analytic_id)],
+                        commit_kwargs = {
+                            "move_line_id": ml.id,
+                            "date": ml.date_commit,
+                            "analytic_account_id": analytic_accounts[int(analytic_id)],
+                        }
+                        reverse_entries.append(
+                            (
+                                expense,
+                                commit_kwargs,
+                                expense._prepare_commit_vals(
+                                    reverse=True, **commit_kwargs
+                                ),
+                            )
                         )
             else:  # Cancel or draft, not commitment line
-                self.env[Expense._budget_model()].search(
-                    [("move_line_id", "=", ml.id)]
-                ).unlink()
+                draft_line_ids.append(ml.id)
+        return reverse_entries, draft_line_ids
+
+    def _create_expense_reverse_entries_batch(self, reverse_entries):
+        # A normal posted expense cannot over-return, so all reversals can be
+        # created together.  Preserve the exact legacy adjustment order for an
+        # exceptional document whose balance exceeds at any intermediate step.
+        # Checking every prefix (not only the final total) also covers mixed
+        # positive/negative expense lines.
+        batch_vals = []
+        batch_period_dates = []
+        entries_by_sheet = {}
+        for entry in reverse_entries:
+            entries_by_sheet.setdefault(entry[0].sheet_id.id, []).append(entry)
+        for entries in entries_by_sheet.values():
+            sheet = entries[0][0].sheet_id
+            existing_moves = sheet.budget_move_ids
+            projected_debit = sum(existing_moves.mapped("debit"))
+            projected_credit = sum(existing_moves.mapped("credit"))
+            use_legacy_order = False
+            for _expense, _commit_kwargs, vals_list in entries:
+                projected_debit += sum(vals["debit"] for vals in vals_list)
+                projected_credit += sum(vals["credit"] for vals in vals_list)
+                if float_compare(projected_credit, projected_debit, 2) == 1:
+                    use_legacy_order = True
+                    break
+            if use_legacy_order:
+                for expense, commit_kwargs, _vals in entries:
+                    expense.commit_budget(reverse=True, **commit_kwargs)
+            else:
+                for expense, _commit_kwargs, vals_list in entries:
+                    batch_vals.extend(vals_list)
+                    # Legacy _update_template_line() resolves the period from
+                    # the source expense date, which can differ from the JE date.
+                    batch_period_dates.extend([expense.date_commit] * len(vals_list))
+
+        if batch_vals:
+            Expense = self.env["hr.expense"]
+            budget_moves = self.env[Expense._budget_model()].create(batch_vals)
+            period_dates = dict(zip(budget_moves.ids, batch_period_dates, strict=False))
+            Expense._update_template_line_batch(budget_moves, period_dates=period_dates)
+
+    def uncommit_expense_budget(self):
+        """Uncommit the budget for related expenses
+        when the vendor bill is in a valid state."""
+        Expense = self.env["hr.expense"]
+        reverse_entries, draft_line_ids = self._prepare_expense_reverse_entries()
+        self._create_expense_reverse_entries_batch(reverse_entries)
+        if draft_line_ids:
+            self.env[Expense._budget_model()].search(
+                [("move_line_id", "in", draft_line_ids)]
+            ).unlink()

--- a/budget_control_expense/models/hr_expense.py
+++ b/budget_control_expense/models/hr_expense.py
@@ -16,19 +16,37 @@ class HRExpense(models.Model):
         inverse_name="expense_id",
     )
 
-    def recompute_budget_move(self):
+    def _recompute_budget_move_sequential(self):
+        """Keep the legacy order for carry-forward, whose checks are sheet-wide."""
         budget_field = self._budget_field()
         force_date_commit = self.env.context.get("force_date_commit", False)
         for expense in self:
-            # Make sure that date_commit not recompute
             ex_date_commit = force_date_commit or expense.date_commit
             expense[budget_field].unlink()
             expense.with_context(force_date_commit=ex_date_commit).commit_budget()
-            # credit will not over debit (auto adjust)
             expense.forward_commit()
+
+    def recompute_budget_move(self):
+        forwarded = self.filtered(
+            lambda expense: expense.fwd_analytic_distribution or expense.fwd_date_commit
+        )
+        if forwarded:
+            # forward_commit() can create an over-return adjustment based on all
+            # moves of the sheet.  Recreate the whole recordset sequentially when
+            # any line is forwarded so intermediate balances stay identical.
+            self._recompute_budget_move_sequential()
+        else:
+            # Normal expenses are independent and can safely share one
+            # unlink/create/template update operation.
+            self.recompute_budget_move_batch()
         self.mapped(
             "sheet_id.account_move_ids.invoice_line_ids"
         ).uncommit_expense_budget()
+
+    def _can_batch_budget_precommit(self):
+        # Advance lines override commit_budget() to use advance.budget.move;
+        # the generic batch helper uses one model for the whole recordset.
+        return not ("advance" in self._fields and any(self.mapped("advance")))
 
     def _init_docline_budget_vals(self, budget_vals, analytic_id):
         self.ensure_one()

--- a/budget_control_expense/models/hr_expense.py
+++ b/budget_control_expense/models/hr_expense.py
@@ -1,75 +1,7 @@
 # Copyright 2020 Ecosoft Co., Ltd. (http://ecosoft.co.th)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import api, fields, models
-
-
-class HRExpenseSheet(models.Model):
-    _inherit = "hr.expense.sheet"
-    _docline_rel = "expense_line_ids"
-    _docline_type = "expense"
-
-    budget_move_ids = fields.One2many(
-        comodel_name="expense.budget.move",
-        inverse_name="sheet_id",
-    )
-
-    @api.constrains("expense_line_ids")
-    def recompute_budget_move(self):
-        self.mapped("expense_line_ids").recompute_budget_move()
-
-    def close_budget_move(self):
-        self.mapped("expense_line_ids").close_budget_move()
-
-    def write(self, vals):
-        """
-        Uncommit the budget when the document state is "approved" or
-        when it is canceled/drafted. If the document is canceled or moved to draft,
-        all budget commitments will be deleted.
-
-        For expenses, the state is a computed field.
-        Therefore, we check the `approval_state` instead:
-            - "approve" = Approved
-            - "cancel" = Canceled
-            - False = To Submit (Draft)
-        """
-        res = super().write(vals)
-        if vals.get("approval_state") in ("approve", "cancel", False):
-            doclines = self.mapped("expense_line_ids")
-            if vals.get("approval_state") in ("cancel", False):
-                doclines.write({"date_commit": False})
-            doclines.recompute_budget_move()
-        return res
-
-    def unlink(self):
-        # Compute commit again after unlink
-        expenses = self.mapped("expense_line_ids")
-        res = super().unlink()
-        expenses._compute_commit()
-        return res
-
-    def action_approve_expense_sheets(self):
-        res = super().action_approve_expense_sheets()
-        BudgetPeriod = self.env["budget.period"]
-        for doc in self:
-            BudgetPeriod.check_budget(doc.expense_line_ids, doc_type="expense")
-        return res
-
-    def action_submit_sheet(self):
-        res = super().action_submit_sheet()
-        BudgetPeriod = self.env["budget.period"]
-        for doc in self:
-            BudgetPeriod.check_budget_precommit(
-                doc.expense_line_ids, doc_type="expense"
-            )
-        return res
-
-    def action_sheet_move_create(self):
-        res = super().action_sheet_move_create()
-        BudgetPeriod = self.env["budget.period"]
-        for doc in self:
-            BudgetPeriod.check_budget(doc.account_move_ids.line_ids)
-        return res
+from odoo import fields, models
 
 
 class HRExpense(models.Model):

--- a/budget_control_expense/models/hr_expense_sheet.py
+++ b/budget_control_expense/models/hr_expense_sheet.py
@@ -1,0 +1,72 @@
+# Copyright 2020 Ecosoft Co., Ltd. (http://ecosoft.co.th)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import api, fields, models
+
+
+class HRExpenseSheet(models.Model):
+    _inherit = "hr.expense.sheet"
+    _docline_rel = "expense_line_ids"
+    _docline_type = "expense"
+
+    budget_move_ids = fields.One2many(
+        comodel_name="expense.budget.move",
+        inverse_name="sheet_id",
+    )
+
+    @api.constrains("expense_line_ids")
+    def recompute_budget_move(self):
+        self.mapped("expense_line_ids").recompute_budget_move()
+
+    def close_budget_move(self):
+        self.mapped("expense_line_ids").close_budget_move()
+
+    def write(self, vals):
+        """
+        Uncommit the budget when the document state is "approved" or
+        when it is canceled/drafted. If the document is canceled or moved to draft,
+        all budget commitments will be deleted.
+
+        For expenses, the state is a computed field.
+        Therefore, we check the `approval_state` instead:
+            - "approve" = Approved
+            - "cancel" = Canceled
+            - False = To Submit (Draft)
+        """
+        res = super().write(vals)
+        if vals.get("approval_state") in ("approve", "cancel", False):
+            doclines = self.mapped("expense_line_ids")
+            if vals.get("approval_state") in ("cancel", False):
+                doclines.write({"date_commit": False})
+            doclines.recompute_budget_move()
+        return res
+
+    def unlink(self):
+        # Compute commit again after unlink
+        expenses = self.mapped("expense_line_ids")
+        res = super().unlink()
+        expenses._compute_commit()
+        return res
+
+    def action_approve_expense_sheets(self):
+        res = super().action_approve_expense_sheets()
+        BudgetPeriod = self.env["budget.period"]
+        for doc in self:
+            BudgetPeriod.check_budget(doc.expense_line_ids, doc_type="expense")
+        return res
+
+    def action_submit_sheet(self):
+        res = super().action_submit_sheet()
+        BudgetPeriod = self.env["budget.period"]
+        for doc in self:
+            BudgetPeriod.check_budget_precommit(
+                doc.expense_line_ids, doc_type="expense"
+            )
+        return res
+
+    def action_sheet_move_create(self):
+        res = super().action_sheet_move_create()
+        BudgetPeriod = self.env["budget.period"]
+        for doc in self:
+            BudgetPeriod.check_budget(doc.account_move_ids.line_ids)
+        return res

--- a/budget_control_expense/models/hr_expense_sheet.py
+++ b/budget_control_expense/models/hr_expense_sheet.py
@@ -63,10 +63,3 @@ class HRExpenseSheet(models.Model):
                 doc.expense_line_ids, doc_type="expense"
             )
         return res
-
-    def action_sheet_move_create(self):
-        res = super().action_sheet_move_create()
-        BudgetPeriod = self.env["budget.period"]
-        for doc in self:
-            BudgetPeriod.check_budget(doc.account_move_ids.line_ids)
-        return res

--- a/budget_control_expense/tests/test_budget_expense.py
+++ b/budget_control_expense/tests/test_budget_expense.py
@@ -3,7 +3,7 @@
 
 from freezegun import freeze_time
 
-from odoo import Command
+from odoo import Command, fields
 from odoo.exceptions import UserError
 from odoo.tests import Form, tagged
 
@@ -267,3 +267,63 @@ class TestBudgetControlExpense(get_budget_common_class()):
         self.budget_control.invalidate_recordset()
         self.assertAlmostEqual(self.budget_control.amount_expense, 0.0)
         self.assertAlmostEqual(self.budget_control.amount_actual, 0.0)
+
+    @freeze_time("2001-02-01")
+    def test_04_batch_precommit_and_reverse_period(self):
+        """Batching keeps manual dates and resolves reversals from expense date."""
+        self.budget_control.action_submit()
+        self.budget_control.action_done()
+        self.budget_period.control_budget = True
+        self.budget_period.control_level = "analytic"
+
+        analytic_distribution = {str(self.costcenter1.id): 100}
+        sheet = self._create_expense_sheet(
+            [
+                {
+                    "product_id": self.product1,
+                    "product_qty": 1,
+                    "price_unit": 30,
+                    "analytic_distribution": analytic_distribution,
+                },
+                {
+                    "product_id": self.product2,
+                    "product_qty": 1,
+                    "price_unit": 40,
+                    "analytic_distribution": analytic_distribution,
+                },
+            ]
+        )
+        expenses = sheet.expense_line_ids.sorted("id")
+        manual_date = fields.Date.to_date("2001-02-10")
+        expenses[0].date_commit = manual_date
+        self.assertTrue(expenses._can_batch_budget_precommit())
+
+        budget_moves, reset_date_lines = expenses._create_precommit_budget_moves_batch()
+        moves_by_expense = {move.expense_id.id: move for move in budget_moves}
+        self.assertEqual(moves_by_expense[expenses[0].id].date, manual_date)
+        self.assertEqual(reset_date_lines, expenses[1])
+        budget_moves.unlink()
+        reset_date_lines.write({"date_commit": False})
+
+        sheet = sheet.with_context(force_date_commit=manual_date)
+        sheet.action_submit_sheet()
+        sheet.action_approve_expense_sheets()
+        sheet.action_sheet_move_post()
+
+        expense = expenses[0]
+        original_template_line = expense.budget_move_ids[:1].template_line_id
+        reverse_moves = expense.budget_move_ids.filtered("move_line_id")
+        reverse_moves.unlink()
+        expense.invalidate_recordset(["amount_commit"])
+
+        move_line = sheet.account_move_ids.invoice_line_ids.filtered(
+            lambda line: line.expense_id == expense
+        )
+        move_line.with_context(
+            skip_account_move_synchronization=True
+        ).date_commit = fields.Date.to_date("2002-01-01")
+        move_line.uncommit_expense_budget()
+
+        reverse_move = expense.budget_move_ids.filtered("move_line_id")
+        self.assertEqual(reverse_move.date, fields.Date.to_date("2002-01-01"))
+        self.assertEqual(reverse_move.template_line_id, original_template_line)


### PR DESCRIPTION
This PR improved performance AV / EX Budgeting and depend on https://github.com/OCA/hr-expense/pull/375
### Benchmark:

| Case | Time Before | Time After |
|---------------|-------------|------------|
| EX Submit 1000 Lines     | 18.4s       | 2.3s        |
| EX Approve 1000 Lines     | 31.6s       | 5.8s        |
| EX Post 1000 Lines     | 356.7s         | 11.8s   |
