### PR TITLE
[15.0][FIX] budget_control_revision: cast revision_number as text instead of char

### DIFF
--- a/budget_allocation_revision/report/budget_source_fund_report.py
+++ b/budget_allocation_revision/report/budget_source_fund_report.py
@@ -12,11 +12,11 @@ class SourceFundMonitorReport(models.Model):
     # Budget
     def _select_budget(self):
         select_budget_query = super()._select_budget()
-        select_budget_query[30] = "bc.revision_number::char as revision_number"
+        select_budget_query[30] = "bc.revision_number::text as revision_number"
         return select_budget_query
 
     # All consumed
     def _select_statement(self, amount_type):
         select_statement = super()._select_statement(amount_type)
-        select_statement[30] = "null::char as revision_number"
+        select_statement[30] = "null::text as revision_number"
         return select_statement

--- a/budget_control_revision/report/budget_monitor_report.py
+++ b/budget_control_revision/report/budget_monitor_report.py
@@ -12,11 +12,11 @@ class BudgetMonitorReport(models.Model):
     # Budget
     def _select_budget(self):
         select_budget_query = super()._select_budget()
-        select_budget_query[70] = "b.revision_number::char as revision_number"
+        select_budget_query[70] = "b.revision_number::text as revision_number"
         return select_budget_query
 
     # All consumed
     def _select_statement(self, amount_type):
         select_statement = super()._select_statement(amount_type)
-        select_statement[70] = "null::char as revision_number"
+        select_statement[70] = "null::text as revision_number"
         return select_statement


### PR DESCRIPTION
::char ใน PSQL คือ character(1) ตัดเหลือตัวอักษรเดียว ทำให้ revision ≥10 ถูก filter ผิดใน _filter_by_budget_control (เช่น revision 11 ถูกอ่านเป็น 1) ส่งผลให้ amount_budget คำนวณผิดเมื่อ budget_control revision ถึงเลข 2 หลัก